### PR TITLE
Add AVB-specific documentation for Intel i210 Ethernet adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ A custom driver has been developed to support AVB-specific features such as gPTP
 6. Follow the on-screen instructions to complete the installation.
 7. Restart your computer to apply the changes.
 
+For detailed AVB-specific documentation, please refer to the [Intel i210 AVB Documentation](docs/Intel_i210_AVB_Documentation.md).
+
 ### GUI-based Tool for AVB Configuration and Monitoring
 A GUI-based tool has been developed to configure and monitor AVB streams, devices, and time synchronization. Follow these steps to use the tool:
 

--- a/docs/Intel_i210_AVB_Documentation.md
+++ b/docs/Intel_i210_AVB_Documentation.md
@@ -1,0 +1,64 @@
+# Intel i210 AVB Documentation
+
+## Overview
+
+This document provides detailed information on the AVB (Audio Video Bridging) functionality, configuration, and usage specific to Intel i210 Ethernet adapters.
+
+## AVB Functionality
+
+### Generalized Precision Time Protocol (gPTP)
+gPTP ensures time synchronization between AVB devices. The Intel i210 supports gPTP, which is essential for maintaining precise timing across the network.
+
+### Audio Video Transport Protocol (AVTP)
+AVTP handles the streaming of audio and video data over AVB networks. The Intel i210 supports AVTP, enabling real-time transmission of multimedia content.
+
+### AV Device Enumeration, Discovery, Connection Management (AVDECC)
+AVDECC manages and controls devices on the AVB network. The Intel i210 supports AVDECC, allowing for the enumeration and management of AVB streams.
+
+## Configuration
+
+### Custom Driver Installation
+To enable AVB functionality on the Intel i210, a custom driver must be installed. Follow these steps:
+
+1. Download the custom driver package from the repository.
+2. Extract the package to a desired location.
+3. Open Device Manager and locate the Intel i210 NIC.
+4. Right-click on the device and select "Update driver".
+5. Choose "Browse my computer for drivers" and navigate to the extracted driver package.
+6. Follow the on-screen instructions to complete the installation.
+7. Restart your computer to apply the changes.
+
+### Time Synchronization Configuration
+To configure gPTP for time synchronization, follow these steps:
+
+1. Ensure the custom driver is installed and the Intel i210 NIC is properly configured.
+2. Download and run the gPTP daemon from the repository.
+3. Monitor the synchronization status using the provided tools.
+
+### Stream Configuration
+To configure AVTP streams, follow these steps:
+
+1. Ensure the custom driver is installed and the Intel i210 NIC is properly configured.
+2. Use the provided AVBTool to create and manage AVTP streams.
+3. Monitor the stream status and adjust settings as needed.
+
+## Usage
+
+### Best Practices
+- Ensure all AVB devices on the network support gPTP for accurate time synchronization.
+- Use high-quality network cables and switches to minimize latency and packet loss.
+- Regularly monitor the network status and adjust configurations as needed.
+
+### Examples
+- Example 1: Configuring a gPTP daemon for time synchronization.
+- Example 2: Creating and managing AVTP streams using AVBTool.
+- Example 3: Enumerating and managing AVB devices using AVDECC.
+
+## Relevant Resources
+
+- [Intel i210 Ethernet Controller Datasheet](https://www.intel.com/content/www/us/en/ethernet-products/controllers/i210-ethernet-controller-datasheet.html)
+- [Intel igb_avb Driver on SourceForge](https://sourceforge.net/projects/e1000/files/igb%20avb%20driver/)
+- [Intel Ethernet Products Documentation](https://www.intel.com/content/www/us/en/ethernet-products/ethernet-products-documentation.html)
+- [Intel Community Discussion on AVB](https://community.intel.com/t5/Ethernet-Products/AVB/td-p/)
+
+These resources provide comprehensive information on how Intel Ethernet adapters, particularly the i210, can be configured and used for AVB. However, most of the detailed support is available for Linux, and as mentioned earlier, AVB support on Windows requires third-party software or modifications.


### PR DESCRIPTION
Related to #3

Add detailed AVB-specific documentation for Intel i210 Ethernet adapters.

* **New Documentation**
  - Add `docs/Intel_i210_AVB_Documentation.md` with detailed information on AVB functionality, configuration, and usage specific to Intel i210 Ethernet adapters.
  - Include sections on gPTP, AVTP, AVDECC, configuration steps, best practices, examples, and relevant resources.

* **README Update**
  - Add a reference to the new `docs/Intel_i210_AVB_Documentation.md` file.
  - Update the "Installation and Configuration" section to mention the new documentation.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/AVB-Windows/issues/3?shareId=a6afdfa5-6c90-4d81-b76d-76817787c66a).