### PR TITLE
Fix CI pipeline build issue

### DIFF
--- a/AVDECC/AVDECC.vcxproj
+++ b/AVDECC/AVDECC.vcxproj
@@ -62,7 +62,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
-      <Optimization>true</Optimization>
+      <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/AVTP/AVTP.vcxproj
+++ b/AVTP/AVTP.vcxproj
@@ -62,7 +62,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
-      <Optimization>true</Optimization>
+      <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/Driver/i210AVBDriver.vcxproj
+++ b/Driver/i210AVBDriver.vcxproj
@@ -62,7 +62,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
-      <Optimization>true</Optimization>
+      <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/GUI/AVBTool.vcxproj
+++ b/GUI/AVBTool.vcxproj
@@ -62,7 +62,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
-      <Optimization>true</Optimization>
+      <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/gPTP/gPTP.vcxproj
+++ b/gPTP/gPTP.vcxproj
@@ -62,7 +62,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
-      <Optimization>true</Optimization>
+      <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>


### PR DESCRIPTION
Related to #20

Fix the invalid value of `<Optimization>` element in multiple project files.

* **AVDECC/AVDECC.vcxproj**
  - Replace the value of `<Optimization>` element from "true" to "MaxSpeed" in the `<ClCompile>` section for the `Release|x64` configuration.
* **AVTP/AVTP.vcxproj**
  - Replace the value of `<Optimization>` element from "true" to "MaxSpeed" in the `<ClCompile>` section for the `Release|x64` configuration.
* **gPTP/gPTP.vcxproj**
  - Replace the value of `<Optimization>` element from "true" to "MaxSpeed" in the `<ClCompile>` section for the `Release|x64` configuration.
* **Driver/i210AVBDriver.vcxproj**
  - Replace the value of `<Optimization>` element from "true" to "MaxSpeed" in the `<ClCompile>` section for the `Release|x64` configuration.
* **GUI/AVBTool.vcxproj**
  - Replace the value of `<Optimization>` element from "true" to "MaxSpeed" in the `<ClCompile>` section for the `Release|x64` configuration.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/AVB-Windows/issues/20?shareId=b62b262b-ef9b-4cae-933b-18207833e81a).