### PR TITLE
Fix CI pipeline error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
     - name: Restore NuGet packages
       run: nuget restore AVB_Windows.sln
 
+    - name: Install dependencies
+      run: pip install -r requirements.txt
+
     - name: Build solution
       run: msbuild AVB_Windows.sln /p:Configuration=Release
 
@@ -88,9 +91,6 @@ jobs:
     - name: Run Error Detection
       run: |
         python scripts/error_detection.py
-
-    - name: Install dependencies
-      run: pip install -r requirements.txt
 
     - name: Run Issue Creation
       if: failure()


### PR DESCRIPTION
Related to #25

Move the `Install dependencies` step before the `Run Error Detection` step in the CI pipeline.

* Add `Install dependencies` step before the `Build solution` step
* Remove duplicate `Install dependencies` step after the `Run Error Detection` step

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/AVB-Windows/issues/25?shareId=b514e6e2-df6a-4484-9979-bbdbad8d63b7).