### PR TITLE
Fix CI pipeline error by adding PyGithub dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,9 @@ jobs:
       run: |
         python scripts/error_detection.py
 
+    - name: Install PyGithub
+      run: pip install PyGithub
+
     - name: Run Issue Creation
       if: failure()
       run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+PyGithub


### PR DESCRIPTION
Related to #25

Fix the CI pipeline error by adding the missing `PyGithub` dependency.

* Add `PyGithub` to `requirements.txt`.
* Add a step in `.github/workflows/ci.yml` to install `PyGithub` before running `scripts/issue_creation.py`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/AVB-Windows/issues/25?shareId=7cc5cd37-468b-4a24-b341-b864d8cdb050).