### PR TITLE
Fix CI pipeline error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,54 @@ jobs:
     - name: Install PyGithub
       run: pip install PyGithub
 
+    - name: Set GITHUB_TOKEN environment variable
+      run: echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
+
     - name: Run Issue Creation
       if: failure()
       run: |
+        python scripts/issue_creation.py
+name: CI
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Setup Visual Studio
+      uses: microsoft/setup-msbuild@v1
+
+    - name: Setup NuGet
+      uses: NuGet/setup-nuget@v1
+
+    - name: Restore NuGet packages
+      run: nuget restore AVB_Windows.sln
+
+    - name: Install dependencies
+      run: pip install -r requirements.txt
+
+    - name: Build solution
+      run: msbuild AVB_Windows.sln /p:Configuration=Release
+
+    - name: Run Unit Tests
+      run: |
+        vstest.console.exe Path\To\Your\TestProject.dll
+
+    - name: Run PVS-Studio Analysis
+      run: |
+        # Install PVS-Studio
+        choco install pvs-studio
+
+    - name: Set GITHUB_TOKEN environment variable
+      if: failure()
         python scripts/issue_creation.py

--- a/scripts/issue_creation.py
+++ b/scripts/issue_creation.py
@@ -1,6 +1,7 @@
 import os
 import requests
 from github import Github
+import sys
 
 def create_github_issue(repo_name, title, body, labels):
     token = os.getenv('GITHUB_TOKEN')
@@ -27,6 +28,10 @@ def create_github_issue(repo_name, title, body, labels):
     return issue
 
 def main():
+    if 'GITHUB_TOKEN' not in os.environ:
+        print("Error: GITHUB_TOKEN environment variable not set")
+        sys.exit(1)
+
     repo_name = "zarfld/AVB-Windows"
     title = "Build Failure on Commit SHA"
     body = """


### PR DESCRIPTION
Related to #25

Add a check for the GITHUB_TOKEN environment variable and set it in the CI pipeline.

* **scripts/issue_creation.py**
  - Import `sys` module.
  - Add a check to see if the `GITHUB_TOKEN` environment variable is set.
  - Print an error message and exit the script if the `GITHUB_TOKEN` environment variable is not set.

* **.github/workflows/ci.yml**
  - Add a step to set the `GITHUB_TOKEN` environment variable using `secrets.GITHUB_TOKEN` provided by GitHub Actions.
  - Add a step to run the `issue_creation.py` script if the previous steps fail.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/AVB-Windows/issues/25?shareId=4a7e9a66-c306-457a-9cf7-035d3eb2ef28).