### PR TITLE
Fix GITHUB_TOKEN for CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,6 @@ jobs:
     - name: Run Issue Creation
       if: failure()
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.TOKEN }}
       run: |
         python scripts/issue_creation.py


### PR DESCRIPTION
Related to #30

Update the `GITHUB_TOKEN` environment variable reference in the GitHub Actions workflow.

* Change the `GITHUB_TOKEN` environment variable to use `${{ secrets.TOKEN }}` instead of `${{ secrets.GITHUB_TOKEN }}` in the `.github/workflows/ci.yml` file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/AVB-Windows/issues/30?shareId=062ccdce-ce7f-4143-b59a-4ebbeb4fb411).