### PR TITLE
Fix build failure on commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,10 @@ jobs:
       run: pip install -r requirements.txt
 
     - name: Build solution
-      run: msbuild AVB_Windows.sln /p:Configuration=Release
+      run: |
+        msbuild AVB_Windows.sln /p:Configuration=Release
+        # Save the build logs to build.log
+        msbuild AVB_Windows.sln /p:Configuration=Release > build.log
 
     - name: Run Unit Tests
       run: |


### PR DESCRIPTION
Related to #36

Add a step to save the build logs to `build.log` in the CI workflow.

* Update the `Build solution` step to save the build logs to `build.log` after building the solution.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/AVB-Windows/issues/36?shareId=61545b4e-c05a-49b7-bfc4-16c2a8ba5bdb).