### PR TITLE
Update CI workflow to use Node.js 20 and v4 of artifact actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,13 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup Visual Studio
-      uses: microsoft/setup-msbuild@v1
+      uses: microsoft/setup-msbuild@v2
 
     - name: Setup NuGet
-      uses: NuGet/setup-nuget@v1
+      uses: NuGet/setup-nuget@v2
 
     - name: Restore NuGet packages
       run: nuget restore AVB_Windows.sln
@@ -110,7 +110,7 @@ jobs:
 
     - name: Upload Build Logs
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: build-logs
         path: build.log

--- a/README.md
+++ b/README.md
@@ -187,13 +187,13 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup Visual Studio
-      uses: microsoft/setup-msbuild@v1
+      uses: microsoft/setup-msbuild@v2
 
     - name: Setup NuGet
-      uses: NuGet/setup-nuget@v1
+      uses: NuGet/setup-nuget@v2
 
     - name: Restore NuGet packages
       run: nuget restore AVB_Windows.sln


### PR DESCRIPTION
Related to #51

Update GitHub Actions workflow to use Node.js version 20 and v4 of the artifact actions.

* **README.md**
  - Update the GitHub Actions workflow example to use `actions/checkout@v4`, `microsoft/setup-msbuild@v2`, `NuGet/setup-nuget@v2`, and `actions/upload-artifact@v4`.

* **.github/workflows/ci.yml**
  - Update `actions/checkout@v3` to `actions/checkout@v4`.
  - Update `microsoft/setup-msbuild@v1` to `microsoft/setup-msbuild@v2`.
  - Update `NuGet/setup-nuget@v1` to `NuGet/setup-nuget@v2`.
  - Update `actions/upload-artifact@v3` to `actions/upload-artifact@v4`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/AVB-Windows/issues/51?shareId=034de630-9e3e-4c1d-a3a2-d17e1dc33024).