### PR TITLE
Fix build failure due to header inclusion order

### DIFF
--- a/AVDECC/AVDECC.cpp
+++ b/AVDECC/AVDECC.cpp
@@ -1,8 +1,9 @@
+#define WIN32_LEAN_AND_MEAN
+#include <winsock2.h>
 #include <windows.h>
 #include <iostream>
 #include <thread>
 #include <vector>
-#include <winsock2.h>
 #include <ws2tcpip.h>
 
 #pragma comment(lib, "Ws2_32.lib")

--- a/GUI/AVBTool.cpp
+++ b/GUI/AVBTool.cpp
@@ -1,3 +1,5 @@
+#define WIN32_LEAN_AND_MEAN
+#include <winsock2.h>
 #include <windows.h>
 #include <iostream>
 #include <vector>
@@ -5,7 +7,6 @@
 #include <thread>
 #include <chrono>
 #include <commctrl.h>
-#include <winsock2.h>
 #include <ws2tcpip.h>
 
 #pragma comment(lib, "Ws2_32.lib")


### PR DESCRIPTION
Related to #36

Resolve build failure due to redefinition and linkage issues with functions from the winsock2.h header.

* **AVDECC/AVDECC.cpp**
  - Define `WIN32_LEAN_AND_MEAN` before including Windows headers.
  - Include `winsock2.h` before `windows.h`.

* **GUI/AVBTool.cpp**
  - Define `WIN32_LEAN_AND_MEAN` before including Windows headers.
  - Include `winsock2.h` before `windows.h`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/AVB-Windows/issues/36?shareId=7fa12e37-86aa-4993-a8dc-8899320a2096).