### PR TITLE
Fix build failure due to winsock2.h redefinition issues

### DIFF
--- a/AVTP/AVTP.cpp
+++ b/AVTP/AVTP.cpp
@@ -1,7 +1,8 @@
+#define WIN32_LEAN_AND_MEAN
+#include <winsock2.h>
 #include <windows.h>
 #include <iostream>
 #include <thread>
-#include <winsock2.h>
 #include <ws2tcpip.h>
 
 #pragma comment(lib, "Ws2_32.lib")

--- a/Driver/i210AVBDriver.cpp
+++ b/Driver/i210AVBDriver.cpp
@@ -1,3 +1,5 @@
+#define WIN32_LEAN_AND_MEAN
+#include <winsock2.h>
 #include <ntddk.h>
 #include <wdf.h>
 #include <wdm.h>

--- a/gPTP/gPTP.cpp
+++ b/gPTP/gPTP.cpp
@@ -1,8 +1,9 @@
+#define WIN32_LEAN_AND_MEAN
+#include <winsock2.h>
 #include <windows.h>
 #include <iostream>
 #include <chrono>
 #include <thread>
-#include <winsock2.h>
 #include <ws2tcpip.h>
 
 #pragma comment(lib, "Ws2_32.lib")


### PR DESCRIPTION
Related to #36

Address redefinition and linkage issues with functions from `winsock2.h`.

* **AVTP/AVTP.cpp**
  - Define `WIN32_LEAN_AND_MEAN` before including Windows headers.
  - Include `winsock2.h` before `windows.h`.

* **Driver/i210AVBDriver.cpp**
  - Define `WIN32_LEAN_AND_MEAN` before including Windows headers.
  - Include `winsock2.h` before `windows.h`.

* **gPTP/gPTP.cpp**
  - Define `WIN32_LEAN_AND_MEAN` before including Windows headers.
  - Include `winsock2.h` before `windows.h`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/AVB-Windows/issues/36?shareId=c3563a20-3048-4834-8414-57bd6df65a47).