### PR TITLE
Fix artifact access issue in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
     branches: [ main, develop ]
 
 permissions:
+  actions: read
+  contents: read
   issues: write
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -180,6 +180,11 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
 jobs:
   build:
 
@@ -223,6 +228,23 @@ jobs:
         clang-format -i -style=file **/*.cpp **/*.h
 
         git diff --exit-code
+
+    - name: Upload Build Logs
+      if: failure()
+      uses: actions/upload-artifact@v3
+      with:
+        name: build-logs
+        path: build.log
+        retention-days: 7
+
+    - name: Run Issue Creation
+      if: failure()
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        COMMIT_SHA: ${{ github.sha }}
+        BUILD_LOGS_LINK: ${{ steps.upload_build_logs.outputs.url }}
+      run: |
+        python scripts/issue_creation.py
 ```
 
 For more details, refer to the [ci.yml](.github/workflows/ci.yml) file in the repository.


### PR DESCRIPTION
Related to #60

Update permissions in workflow file to fix artifact access issue.

* Add `actions: read` and `contents: read` permissions to the `permissions` section in `.github/workflows/ci.yml`.
* Add instructions in `README.md` for setting the required permissions in the workflow file.
* Add `Upload Build Logs` and `Run Issue Creation` steps in `README.md` example workflow.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/AVB-Windows/issues/60?shareId=28b59384-7dfa-45f5-a4c7-3e70bf4d112d).