### PR TITLE
Update Node.js version and artifact actions in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,13 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup Visual Studio
-      uses: microsoft/setup-msbuild@v1
+      uses: microsoft/setup-msbuild@v2
 
     - name: Setup NuGet
-      uses: NuGet/setup-nuget@v1
+      uses: NuGet/setup-nuget@v2
 
     - name: Restore NuGet packages
       run: nuget restore AVB_Windows.sln
@@ -115,7 +115,7 @@ jobs:
 
     - name: Upload Build Logs
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: build-logs
         path: build.log

--- a/README.md
+++ b/README.md
@@ -192,13 +192,13 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup Visual Studio
-      uses: microsoft/setup-msbuild@v1
+      uses: microsoft/setup-msbuild@v2
 
     - name: Setup NuGet
-      uses: NuGet/setup-nuget@v1
+      uses: NuGet/setup-nuget@v2
 
     - name: Restore NuGet packages
       run: nuget restore AVB_Windows.sln
@@ -231,7 +231,7 @@ jobs:
 
     - name: Upload Build Logs
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: build-logs
         path: build.log


### PR DESCRIPTION
Related to #51

Update CI workflow to use Node.js version 20 and v4 of artifact actions.

* **README.md**
  - Update `actions/checkout@v3` to `actions/checkout@v4`
  - Update `microsoft/setup-msbuild@v1` to `microsoft/setup-msbuild@v2`
  - Update `NuGet/setup-nuget@v1` to `NuGet/setup-nuget@v2`
  - Update `actions/upload-artifact@v3` to `actions/upload-artifact@v4`

* **.github/workflows/ci.yml**
  - Update `actions/checkout@v3` to `actions/checkout@v4`
  - Update `microsoft/setup-msbuild@v1` to `microsoft/setup-msbuild@v2`
  - Update `NuGet/setup-nuget@v1` to `NuGet/setup-nuget@v2`
  - Update `actions/upload-artifact@v3` to `actions/upload-artifact@v4`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/AVB-Windows/issues/51?shareId=af04e7a6-5810-4b31-926f-5d7f151cb8a7).