### PR TITLE
Fix build errors related to 'ntddk.h' and 'LPCWSTR' conversion

### DIFF
--- a/AVDECC/AVDECC.cpp
+++ b/AVDECC/AVDECC.cpp
@@ -89,7 +89,7 @@ void AVDECC::manageStreams() {
 
 void AVDECC::discoverDevices() {
     const char* discoverMessage = "DISCOVER";
-    int result = sendto(sock, discoverMessage, strlen(discoverMessage), 0, (sockaddr*)&serverAddr, sizeof(serverAddr));
+    int result = sendto(sock, discoverMessage, static_cast<int>(strlen(discoverMessage)), 0, (sockaddr*)&serverAddr, sizeof(serverAddr));
     if (result == SOCKET_ERROR) {
         std::cerr << "Send failed with error: " << WSAGetLastError() << std::endl;
         return;
@@ -97,7 +97,7 @@ void AVDECC::discoverDevices() {
 
     char buffer[1024];
     int serverAddrSize = sizeof(serverAddr);
-    result = recvfrom(sock, buffer, sizeof(buffer), 0, (sockaddr*)&serverAddr, &serverAddrSize);
+    result = recvfrom(sock, buffer, static_cast<int>(sizeof(buffer)), 0, (sockaddr*)&serverAddr, &serverAddrSize);
     if (result == SOCKET_ERROR) {
         std::cerr << "Receive failed with error: " << WSAGetLastError() << std::endl;
     } else {

--- a/AVTP/AVTP.cpp
+++ b/AVTP/AVTP.cpp
@@ -76,8 +76,8 @@ void AVTP::handleStream() {
 
 void AVTP::captureAVBFrames() {
     char buffer[2048];
-    int serverAddrSize = sizeof(serverAddr);
-    int result = recvfrom(sock, buffer, sizeof(buffer), 0, (sockaddr*)&serverAddr, &serverAddrSize);
+    int serverAddrSize = static_cast<int>(sizeof(serverAddr));
+    int result = recvfrom(sock, buffer, static_cast<int>(sizeof(buffer)), 0, (sockaddr*)&serverAddr, &serverAddrSize);
     if (result == SOCKET_ERROR) {
         std::cerr << "Receive failed with error: " << WSAGetLastError() << std::endl;
     } else {

--- a/Driver/i210AVBDriver.vcxproj
+++ b/Driver/i210AVBDriver.vcxproj
@@ -28,6 +28,7 @@
     <PostBuildEvent>
       <Command>copy "$(OutDir)$(TargetName).exe" "$(SolutionDir)build.log"</Command>
     </PostBuildEvent>
+    <AdditionalIncludeDirectories>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)include;$(SolutionDir)Driver\include;$(SolutionDir)Driver\ntddk;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Driver</ConfigurationType>
@@ -42,6 +43,7 @@
     <PostBuildEvent>
       <Command>copy "$(OutDir)$(TargetName).exe" "$(SolutionDir)build.log"</Command>
     </PostBuildEvent>
+    <AdditionalIncludeDirectories>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)include;$(SolutionDir)Driver\include;$(SolutionDir)Driver\ntddk;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/GUI/AVBTool.cpp
+++ b/GUI/AVBTool.cpp
@@ -56,13 +56,13 @@ void AVBTool::initializeWindow() {
     WNDCLASS wc = { 0 };
     wc.lpfnWndProc = WindowProc;
     wc.hInstance = hInstance;
-    wc.lpszClassName = "AVBToolClass";
+    wc.lpszClassName = TEXT("AVBToolClass");
     RegisterClass(&wc);
 
-    hwndMain = CreateWindowEx(0, "AVBToolClass", "AVB Tool", WS_OVERLAPPEDWINDOW, CW_USEDEFAULT, CW_USEDEFAULT, 800, 600, NULL, NULL, hInstance, this);
-    hwndList = CreateWindowEx(0, WC_LISTVIEW, "", WS_CHILD | WS_VISIBLE | LVS_REPORT, 10, 10, 760, 400, hwndMain, NULL, hInstance, NULL);
-    hwndStartButton = CreateWindowEx(0, "BUTTON", "Start", WS_CHILD | WS_VISIBLE, 10, 420, 100, 30, hwndMain, (HMENU)1, hInstance, NULL);
-    hwndStopButton = CreateWindowEx(0, "BUTTON", "Stop", WS_CHILD | WS_VISIBLE, 120, 420, 100, 30, hwndMain, (HMENU)2, hInstance, NULL);
+    hwndMain = CreateWindowEx(0, TEXT("AVBToolClass"), TEXT("AVB Tool"), WS_OVERLAPPEDWINDOW, CW_USEDEFAULT, CW_USEDEFAULT, 800, 600, NULL, NULL, hInstance, this);
+    hwndList = CreateWindowEx(0, WC_LISTVIEW, TEXT(""), WS_CHILD | WS_VISIBLE | LVS_REPORT, 10, 10, 760, 400, hwndMain, NULL, hInstance, NULL);
+    hwndStartButton = CreateWindowEx(0, TEXT("BUTTON"), TEXT("Start"), WS_CHILD | WS_VISIBLE, 10, 420, 100, 30, hwndMain, (HMENU)1, hInstance, NULL);
+    hwndStopButton = CreateWindowEx(0, TEXT("BUTTON"), TEXT("Stop"), WS_CHILD | WS_VISIBLE, 120, 420, 100, 30, hwndMain, (HMENU)2, hInstance, NULL);
 
     ShowWindow(hwndMain, SW_SHOW);
 }

--- a/gPTP/gPTP.cpp
+++ b/gPTP/gPTP.cpp
@@ -77,7 +77,7 @@ void gPTP::synchronize() {
 
 void gPTP::sendSyncMessage() {
     const char* syncMessage = "SYNC";
-    int result = sendto(sock, syncMessage, strlen(syncMessage), 0, (sockaddr*)&serverAddr, sizeof(serverAddr));
+    int result = sendto(sock, syncMessage, static_cast<int>(strlen(syncMessage)), 0, (sockaddr*)&serverAddr, sizeof(serverAddr));
     if (result == SOCKET_ERROR) {
         std::cerr << "Send failed with error: " << WSAGetLastError() << std::endl;
     }
@@ -85,8 +85,8 @@ void gPTP::sendSyncMessage() {
 
 void gPTP::receiveSyncMessage() {
     char buffer[1024];
-    int serverAddrSize = sizeof(serverAddr);
-    int result = recvfrom(sock, buffer, sizeof(buffer), 0, (sockaddr*)&serverAddr, &serverAddrSize);
+    int serverAddrSize = static_cast<int>(sizeof(serverAddr));
+    int result = recvfrom(sock, buffer, static_cast<int>(sizeof(buffer)), 0, (sockaddr*)&serverAddr, &serverAddrSize);
     if (result == SOCKET_ERROR) {
         std::cerr << "Receive failed with error: " << WSAGetLastError() << std::endl;
     } else {


### PR DESCRIPTION
Related to #67

Fix build errors related to 'ntddk.h' and 'LPCWSTR' conversion.

* Add the correct include path for 'ntddk.h' in `Driver/i210AVBDriver.vcxproj` for both Debug and Release configurations.
* Use the `TEXT` macro for string literals in `GUI/AVBTool.cpp` to resolve 'LPCWSTR' conversion errors.
* Use `static_cast<int>` to explicitly convert `size_t` to `int` in `AVDECC/AVDECC.cpp`, `AVTP/AVTP.cpp`, and `gPTP/gPTP.cpp`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/AVB-Windows/issues/67?shareId=119ce7a7-b6c5-41a9-920b-293c837aae00).