### PR TITLE
Fix invalid workflow file in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
 
     runs-on: windows-latest
 
+    outputs:
+      url: ${{ steps.upload_build_logs.outputs.url }}
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -115,14 +118,13 @@ jobs:
 
     - name: Upload Build Logs
       if: failure()
+      id: upload_build_logs
       uses: actions/upload-artifact@v4
       with:
         name: build-logs
         path: build.log
         retention-days: 7
         if-no-files-found: error
-      outputs:
-        url: ${{ steps.upload_build_logs.outputs.url }}
 
     - name: Check for Missing Logs
       run: |

--- a/README.md
+++ b/README.md
@@ -190,6 +190,9 @@ jobs:
 
     runs-on: windows-latest
 
+    outputs:
+      url: ${{ steps.upload_build_logs.outputs.url }}
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -231,11 +234,13 @@ jobs:
 
     - name: Upload Build Logs
       if: failure()
+      id: upload_build_logs
       uses: actions/upload-artifact@v4
       with:
         name: build-logs
         path: build.log
         retention-days: 7
+        if-no-files-found: error
 
     - name: Run Issue Creation
       if: failure()


### PR DESCRIPTION
Related to #69

Fix invalid workflow file by moving `outputs` section to job level and adding `id` field to `Upload Build Logs` step.

* Move the `outputs` section from the step level to the job level in `.github/workflows/ci.yml`.
* Add the `outputs` section under the job definition in `.github/workflows/ci.yml`.
* Set the output value using the `steps.upload_build_logs.outputs.url` syntax in `.github/workflows/ci.yml`.
* Add the `id` field to the `Upload Build Logs` step in `.github/workflows/ci.yml`.
* Update the example GitHub Actions workflow in `README.md` to reflect the correct syntax for defining outputs at the job level.
* Ensure the `Upload Build Logs` step in `README.md` has an `id` field and references the output correctly.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/AVB-Windows/issues/69?shareId=35e1dfda-5bc9-4aa7-982f-d165b305b674).