### PR TITLE
Fix build errors and warnings

### DIFF
--- a/AVTP/AVTP.vcxproj
+++ b/AVTP/AVTP.vcxproj
@@ -64,7 +64,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>false</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_WINSOCK_DEPRECATED_NO_WARNINGS;_WINSOCKAPI_;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_WINSOCK_DEPRECATED_NO_WARNINGS;WIN32_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
@@ -80,7 +80,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_WINSOCK_DEPRECATED_NO_WARNINGS;_WINSOCKAPI_;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_WINSOCK_DEPRECATED_NO_WARNINGS;WIN32_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>

--- a/Driver/i210AVBDriver.vcxproj
+++ b/Driver/i210AVBDriver.vcxproj
@@ -66,7 +66,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>false</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_WINSOCK_DEPRECATED_NO_WARNINGS;_WINSOCKAPI_;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_WINSOCK_DEPRECATED_NO_WARNINGS;WIN32_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
@@ -82,7 +82,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_WINSOCK_DEPRECATED_NO_WARNINGS;_WINSOCKAPI_;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_WINSOCK_DEPRECATED_NO_WARNINGS;WIN32_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>

--- a/GUI/AVBTool.cpp
+++ b/GUI/AVBTool.cpp
@@ -108,14 +108,14 @@ void AVBTool::stopSynchronization() {
 void AVBTool::synchronize() {
     while (running) {
         const char* syncMessage = "SYNC";
-        int result = sendto(sock, syncMessage, strlen(syncMessage), 0, (sockaddr*)&serverAddr, sizeof(serverAddr));
+        int result = sendto(sock, syncMessage, static_cast<int>(strlen(syncMessage)), 0, (sockaddr*)&serverAddr, sizeof(serverAddr));
         if (result == SOCKET_ERROR) {
             std::cerr << "Send failed with error: " << WSAGetLastError() << std::endl;
         }
 
         char buffer[1024];
         int serverAddrSize = sizeof(serverAddr);
-        result = recvfrom(sock, buffer, sizeof(buffer), 0, (sockaddr*)&serverAddr, &serverAddrSize);
+        result = recvfrom(sock, buffer, static_cast<int>(sizeof(buffer)), 0, (sockaddr*)&serverAddr, &serverAddrSize);
         if (result == SOCKET_ERROR) {
             std::cerr << "Receive failed with error: " << WSAGetLastError() << std::endl;
         } else {
@@ -130,7 +130,7 @@ void AVBTool::synchronize() {
 void AVBTool::discoverDevices() {
     while (running) {
         const char* discoverMessage = "DISCOVER";
-        int result = sendto(sock, discoverMessage, strlen(discoverMessage), 0, (sockaddr*)&serverAddr, sizeof(serverAddr));
+        int result = sendto(sock, discoverMessage, static_cast<int>(strlen(discoverMessage)), 0, (sockaddr*)&serverAddr, sizeof(serverAddr));
         if (result == SOCKET_ERROR) {
             std::cerr << "Send failed with error: " << WSAGetLastError() << std::endl;
             return;
@@ -138,7 +138,7 @@ void AVBTool::discoverDevices() {
 
         char buffer[1024];
         int serverAddrSize = sizeof(serverAddr);
-        result = recvfrom(sock, buffer, sizeof(buffer), 0, (sockaddr*)&serverAddr, &serverAddrSize);
+        result = recvfrom(sock, buffer, static_cast<int>(sizeof(buffer)), 0, (sockaddr*)&serverAddr, &serverAddrSize);
         if (result == SOCKET_ERROR) {
             std::cerr << "Receive failed with error: " << WSAGetLastError() << std::endl;
         } else {

--- a/GUI/AVBTool.vcxproj
+++ b/GUI/AVBTool.vcxproj
@@ -69,7 +69,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
-      <SubSystem>Console</SubSystem>
+      <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
@@ -85,7 +85,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
-      <SubSystem>Console</SubSystem>
+      <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>

--- a/gPTP/gPTP.vcxproj
+++ b/gPTP/gPTP.vcxproj
@@ -64,7 +64,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>false</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_WINSOCK_DEPRECATED_NO_WARNINGS;_WINSOCKAPI_;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_WINSOCK_DEPRECATED_NO_WARNINGS;WIN32_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
@@ -80,7 +80,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_WINSOCK_DEPRECATED_NO_WARNINGS;_WINSOCKAPI_;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_WINSOCK_DEPRECATED_NO_WARNINGS;WIN32_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>


### PR DESCRIPTION
Related to #71

Fix build errors and warnings in the project.

* **GUI/AVBTool.vcxproj**: Change `<SubSystem>` property from `Console` to `Windows` to match the `WinMain` entry point.
* **GUI/AVBTool.cpp**: Add explicit type casting to resolve 'size_t' to 'int' conversion warnings at lines 111 and 133.
* **AVTP/AVTP.vcxproj**: Define `WIN32_LEAN_AND_MEAN` before including any Windows headers to resolve `_WINSOCKAPI_` macro redefinition warnings.
* **gPTP/gPTP.vcxproj**: Define `WIN32_LEAN_AND_MEAN` before including any Windows headers to resolve `_WINSOCKAPI_` macro redefinition warnings.
* **Driver/i210AVBDriver.vcxproj**: Define `WIN32_LEAN_AND_MEAN` before including any Windows headers to resolve `_WINSOCKAPI_` macro redefinition warnings.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/AVB-Windows/issues/71?shareId=862e790e-2b49-445b-86ca-27a42411e301).