### PR TITLE
Fix build failure due to missing ntddk.h

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,13 @@ jobs:
     - name: Install dependencies
       run: pip install -r requirements.txt
 
+    - name: Install Windows Driver Kit (WDK)
+      run: choco install windows-driver-kit
+
+    - name: Set WDK environment variables
+      run: |
+        echo "WDK_IncludePath=C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0" >> $GITHUB_ENV
+
     - name: Clean solution
       run: msbuild AVB_Windows.sln /t:Clean
 

--- a/AVB_Windows.sln
+++ b/AVB_Windows.sln
@@ -42,4 +42,7 @@ Global
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		WDK_IncludePath = C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0
+	EndGlobalSection
 EndGlobal

--- a/Driver/i210AVBDriver.vcxproj
+++ b/Driver/i210AVBDriver.vcxproj
@@ -28,7 +28,7 @@
     <PostBuildEvent>
       <Command>copy "$(OutDir)$(TargetName).exe" "$(SolutionDir)build.log"</Command>
     </PostBuildEvent>
-    <AdditionalIncludeDirectories>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)include;$(SolutionDir)Driver\include;$(SolutionDir)Driver\ntddk;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    <AdditionalIncludeDirectories>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)include;$(SolutionDir)Driver\include;$(SolutionDir)Driver\ntddk;$(WDK_IncludePath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Driver</ConfigurationType>
@@ -43,7 +43,7 @@
     <PostBuildEvent>
       <Command>copy "$(OutDir)$(TargetName).exe" "$(SolutionDir)build.log"</Command>
     </PostBuildEvent>
-    <AdditionalIncludeDirectories>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)include;$(SolutionDir)Driver\include;$(SolutionDir)Driver\ntddk;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    <AdditionalIncludeDirectories>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)include;$(SolutionDir)Driver\include;$(SolutionDir)Driver\ntddk;$(WDK_IncludePath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">


### PR DESCRIPTION
Related to #73

Fix the build error by including the Windows Driver Kit (WDK) in the project and CI workflow.

* **Driver/i210AVBDriver.vcxproj**
  - Add `$(WDK_IncludePath)` to `AdditionalIncludeDirectories` property for both Debug and Release configurations.

* **.github/workflows/ci.yml**
  - Add step to install Windows Driver Kit (WDK) before building the solution.
  - Set WDK environment variables in the CI workflow.

* **AVB_Windows.sln**
  - Add reference to WDK in the solution file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/AVB-Windows/issues/73?shareId=646e671b-b2fd-4462-8174-b32f825da283).