### PR TITLE
'WIN32_LEAN_AND_MEAN': macro redefinition

### DIFF
--- a/AVTP/AVTP.cpp
+++ b/AVTP/AVTP.cpp
@@ -1,4 +1,6 @@
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 #include <winsock2.h>
 #include <windows.h>
 #include <iostream>

--- a/Driver/i210AVBDriver.cpp
+++ b/Driver/i210AVBDriver.cpp
@@ -1,4 +1,6 @@
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 #include <winsock2.h>
 #include <ntddk.h>
 #include <wdf.h>

--- a/gPTP/gPTP.cpp
+++ b/gPTP/gPTP.cpp
@@ -1,4 +1,6 @@
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 #include <winsock2.h>
 #include <windows.h>
 #include <iostream>


### PR DESCRIPTION
Related to #78

Wrap the `#define WIN32_LEAN_AND_MEAN` macro with `#ifndef` and `#endif` in the AVTP, gPTP, and i210AVBDriver projects to resolve the macro redefinition warning.

* **AVTP/AVTP.cpp**
  - Add `#ifndef WIN32_LEAN_AND_MEAN` before `#define WIN32_LEAN_AND_MEAN`
  - Add `#endif` after `#define WIN32_LEAN_AND_MEAN`

* **gPTP/gPTP.cpp**
  - Add `#ifndef WIN32_LEAN_AND_MEAN` before `#define WIN32_LEAN_AND_MEAN`
  - Add `#endif` after `#define WIN32_LEAN_AND_MEAN`

* **Driver/i210AVBDriver.cpp**
  - Add `#ifndef WIN32_LEAN_AND_MEAN` before `#define WIN32_LEAN_AND_MEAN`
  - Add `#endif` after `#define WIN32_LEAN_AND_MEAN`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/AVB-Windows/issues/78?shareId=8672a004-f079-4567-aa8e-9af087454135).