### PR TITLE
Fix include path for ntddk.h

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,12 +40,8 @@ jobs:
 
     - name: Verify Windows Driver Kit (WDK) Installation
       run: |
-        if choco list --local-only | findstr /i "windowsdriverkit10"; then
-          echo "WDK is installed."
-        else
-          echo "WDK is not installed."
-          exit 1
-        fi
+        ./scripts/verify_wdk_installation.sh
+      shell: bash
 
     - name: Set WDK environment variables
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,15 @@ jobs:
     - name: Install Windows Driver Kit (WDK)
       run: choco install windowsdriverkit10 --source=https://chocolatey.org/api/v2/
 
+    - name: Verify Windows Driver Kit (WDK) Installation
+      run: |
+        if choco list --local-only | findstr /i "windowsdriverkit10"; then
+          echo "WDK is installed."
+        else
+          echo "WDK is not installed."
+          exit 1
+        fi
+
     - name: Set WDK environment variables
       run: |
         echo "WDK_IncludePath=C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0" >> $GITHUB_ENV
@@ -162,14 +171,12 @@ jobs:
         if [ "$issue_status" == "in progress" ]; then
           echo "Triggering CI pipeline for issue progress"
           # Add logic to trigger CI pipeline
-        fi
 
     - name: CI Pipeline Alerts for Failed Builds
       run: |
         if [ -f build.log ]; then
           echo "Build failed. Sending alerts."
           # Add logic to send alerts via Slack, email, or GitHub notifications
-        fi
 
     - name: Use Separate Labels for Environments
       run: |
@@ -183,7 +190,6 @@ jobs:
         elif [ "$environment" == "production" ]; then
           echo "Labeling as 'in production'"
           # Add logic to label issues as 'in production'
-        fi
 
     - name: Enforce Branch Protection Rules
       run: |
@@ -192,7 +198,6 @@ jobs:
         if [ -z "$protection_rules" ]; then
           echo "Enforcing branch protection rules"
           # Add logic to enforce branch protection rules
-        fi
 
     - name: Continuous Deployment Labels and Issue Auto-Close
       run: |
@@ -200,7 +205,6 @@ jobs:
         if [ "$deployment_status" == "success" ]; then
           echo "Deployment successful. Auto-closing issues."
           # Add logic to auto-close issues
-        fi
 
     - name: Enforce Issue Templates and CI Requirements
       run: |
@@ -208,7 +212,6 @@ jobs:
         if [ -f .github/ISSUE_TEMPLATE/$issue_template ]; then
           echo "Enforcing issue templates"
           # Add logic to enforce issue templates
-        fi
 
     - name: Integrate Monitoring and Feedback Tools
       run: |
@@ -216,4 +219,3 @@ jobs:
         if [ "$monitoring_tool" == "Datadog" ]; then
           echo "Integrating Datadog for monitoring and feedback"
           # Add logic to integrate Datadog
-        fi

--- a/Driver/i210AVBDriver.vcxproj
+++ b/Driver/i210AVBDriver.vcxproj
@@ -28,7 +28,7 @@
     <PostBuildEvent>
       <Command>copy "$(OutDir)$(TargetName).exe" "$(SolutionDir)build.log"</Command>
     </PostBuildEvent>
-    <AdditionalIncludeDirectories>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)include;$(SolutionDir)Driver\include;$(SolutionDir)Driver\ntddk;$(WDK_IncludePath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    <AdditionalIncludeDirectories>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)include;$(SolutionDir)Driver\include;$(SolutionDir)Driver\ntddk;$(WDK_IncludePath);$(WDK_IncludePath)\km;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Driver</ConfigurationType>
@@ -43,7 +43,7 @@
     <PostBuildEvent>
       <Command>copy "$(OutDir)$(TargetName).exe" "$(SolutionDir)build.log"</Command>
     </PostBuildEvent>
-    <AdditionalIncludeDirectories>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)include;$(SolutionDir)Driver\include;$(SolutionDir)Driver\ntddk;$(WDK_IncludePath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    <AdditionalIncludeDirectories>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)include;$(SolutionDir)Driver\include;$(SolutionDir)Driver\ntddk;$(WDK_IncludePath);$(WDK_IncludePath)\km;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/scripts/verify_wdk_installation.sh
+++ b/scripts/verify_wdk_installation.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Check if the windowsdriverkit10 package is installed
+if choco list --local-only | findstr /i "windowsdriverkit10"; then
+  echo "WDK is installed."
+else
+  echo "WDK is not installed."
+  exit 1
+fi


### PR DESCRIPTION
Related to #82

Fix the build error by updating include directories and verifying WDK installation.

* **Driver/i210AVBDriver.vcxproj**
  - Add `$(WDK_IncludePath)\km` to `AdditionalIncludeDirectories` in both Debug and Release configurations.
  - Ensure `$(WDK_IncludePath)` is included in `AdditionalIncludeDirectories` in both Debug and Release configurations.

* **.github/workflows/ci.yml**
  - Add step to verify `windowsdriverkit10` package installation.
  - Ensure `WDK_IncludePath` is set correctly to `C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/AVB-Windows/issues/82?shareId=7d9bdac7-02f2-4cd3-a366-ad95f7324ed6).