### PR TITLE
Fix build failure by updating platform toolset

### DIFF
--- a/Driver/i210AVBDriver.vcxproj
+++ b/Driver/i210AVBDriver.vcxproj
@@ -19,7 +19,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Driver</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>WindowsKernelModeDriver</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
     <IntDir>$(Configuration)\$(ProjectName)\</IntDir>
@@ -33,7 +33,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Driver</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>WindowsKernelModeDriver</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <OutDir>$(SolutionDir)$(Configuration)\</OutDir>


### PR DESCRIPTION
Related to #92

Update `Driver/i210AVBDriver.vcxproj` to use `WindowsKernelModeDriver` platform toolset.

* Change `<PlatformToolset>` to `WindowsKernelModeDriver` in Debug configuration.
* Change `<PlatformToolset>` to `WindowsKernelModeDriver` in Release configuration.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/AVB-Windows/issues/92?shareId=1d95057d-3c8a-40b4-8847-ecd32e32e179).