### PR TITLE
Fix build failure due to missing ntddk.h

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,16 @@ jobs:
         ./scripts/verify_wdk_installation.sh
       shell: bash
 
+    - name: Verify WDK_IncludePath Environment Variable
+      run: |
+        if [ -z "$WDK_IncludePath" ]; then
+          echo "WDK_IncludePath environment variable is not set."
+          exit 1
+        else
+          echo "WDK_IncludePath is set to: $WDK_IncludePath"
+        fi
+      shell: bash
+
     - name: Clean solution
       run: msbuild AVB_Windows.sln /t:Clean
 


### PR DESCRIPTION
Related to #92

Add a step to verify the `WDK_IncludePath` environment variable in the CI workflow.

* Add a new step in `.github/workflows/ci.yml` to check if the `WDK_IncludePath` environment variable is set and output its value.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/AVB-Windows/issues/92?shareId=ab543d67-f7af-4df1-a684-8e4520ecf514).