### PR TITLE
Fix build failure due to missing ntddk.h

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       run: pip install -r requirements.txt
 
     - name: Install Windows SDK
-      run: choco install windows-sdk-10.0 --version=10.0.22621.0 --source=https://chocolatey.org/api/v2/
+      run: choco install windows-sdk-10.1 --source=https://chocolatey.org/api/v2/
 
     - name: Install Windows Driver Kit (WDK)
       run: choco install windowsdriverkit10 --source=https://chocolatey.org/api/v2/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
     - name: Install dependencies
       run: pip install -r requirements.txt
 
+    - name: Install Windows SDK
+      run: choco install windows-sdk-10.0 --version=10.0.22621.0 --source=https://chocolatey.org/api/v2/
+
     - name: Install Windows Driver Kit (WDK)
       run: choco install windowsdriverkit10 --source=https://chocolatey.org/api/v2/
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,15 @@ jobs:
         ./scripts/verify_wdk_installation.sh
       shell: bash
 
+    - name: Verify Windows SDK Installation
+      run: |
+        if [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0" ]; then
+          echo "Windows SDK is properly installed."
+        else
+          echo "Windows SDK is not properly installed."
+          exit 1
+        fi
+
     - name: Clean solution
       run: msbuild AVB_Windows.sln /t:Clean
 

--- a/README.md
+++ b/README.md
@@ -444,3 +444,33 @@ For more details, refer to the [ci.yml](.github/workflows/ci.yml) file in the re
 - **Porting Open Source Code**: Adapting existing open-source AVB components to work on Windows.
 - **Performance Optimization**: Ensuring the AVB stack and driver are optimized for performance on Windows.
 - **Testing and Validation**: Building test environments to ensure compatibility and functionality with AVB networks and devices.
+
+### Installing the Windows SDK using Chocolatey
+
+To install the Windows SDK using Chocolatey, follow these steps:
+
+1. Open a command prompt with administrative privileges.
+2. Run the following command to install the Windows SDK:
+   ```sh
+   choco install windows-sdk-10.1 --source=https://chocolatey.org/api/v2/
+   ```
+
+This command installs the Windows SDK version 10.1 from the Chocolatey package repository.
+
+### Verifying the Windows SDK Installation
+
+After installing the Windows SDK, it is important to verify that it is properly installed. You can add a step in your CI pipeline to check the installation:
+
+* Add a step to verify the Windows SDK installation in the `.github/workflows/ci.yml` file:
+  ```yaml
+  - name: Verify Windows SDK Installation
+    run: |
+      if [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0" ]; then
+        echo "Windows SDK is properly installed."
+      else
+        echo "Windows SDK is not properly installed."
+        exit 1
+      fi
+  ```
+
+This step ensures that the Windows SDK is installed correctly and is compatible with the WDK.

--- a/scripts/verify_wdk_installation.sh
+++ b/scripts/verify_wdk_installation.sh
@@ -35,3 +35,11 @@ echo "Debugging information for Driver/i210AVBDriver.cpp:"
 echo "Path: $(realpath Driver/i210AVBDriver.cpp)"
 echo "Files in directory:"
 ls -l Driver/
+
+# Check if the Windows SDK is installed and compatible with the WDK
+if [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0" ]; then
+  echo "Windows SDK is properly installed."
+else
+  echo "Windows SDK is not properly installed."
+  exit 1
+fi


### PR DESCRIPTION
Related to #92

Add verification step for Windows SDK installation in CI pipeline.

* Add a step in `.github/workflows/ci.yml` to verify Windows SDK installation for compatibility with WDK.
* Update `scripts/verify_wdk_installation.sh` to check for the presence of Windows SDK and log the output for troubleshooting.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/AVB-Windows/issues/92?shareId=fd99a2a1-2df1-4ac0-9565-c21b3a50af12).