### PR TITLE
Add SDK verification script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,14 +52,12 @@ jobs:
         ./scripts/verify_wdk_installation.sh
       shell: bash
 
+    - name: Set executable permissions for verify_sdk_installation.sh
+      run: chmod +x ./scripts/verify_sdk_installation.sh
+
     - name: Verify Windows SDK Installation
-      run: |
-        if [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0" ]; then
-          echo "Windows SDK is properly installed."
-        else
-          echo "Windows SDK is not properly installed."
-          exit 1
-        fi
+      run: ./scripts/verify_sdk_installation.sh
+      shell: bash
 
     - name: Clean solution
       run: msbuild AVB_Windows.sln /t:Clean

--- a/scripts/verify_sdk_installation.sh
+++ b/scripts/verify_sdk_installation.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0" ]; then
+  echo "Windows SDK is properly installed."
+else
+  echo "Windows SDK is not properly installed."
+  exit 1
+fi


### PR DESCRIPTION
Related to #97

Add a script to verify Windows SDK installation and update CI workflow.

* **Add `scripts/verify_sdk_installation.sh`**
  - Create a new Bash script to verify the SDK installation.
  - Check the existence of the SDK directory.
  - Exit with code 1 if the SDK is not properly installed.

* **Update `.github/workflows/ci.yml`**
  - Remove the inline script for SDK verification.
  - Add a step to set executable permissions for `verify_sdk_installation.sh`.
  - Add a step to run the `verify_sdk_installation.sh` script.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/AVB-Windows/issues/97?shareId=c311bb35-fa1e-4771-a78a-684902b21ce6).