### PR TITLE
Fix build failure due to missing WindowsKernelModeDriver build tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
     - name: Install Windows Driver Kit (WDK)
       run: choco install windowsdriverkit10 --source=https://chocolatey.org/api/v2/
 
+    - name: Install WindowsKernelModeDriver build tools
+      run: choco install windowskernelmodedriver --source=https://chocolatey.org/api/v2/
+
     - name: Set executable permissions for verify_wdk_installation.sh
       run: chmod +x ./scripts/verify_wdk_installation.sh
 
@@ -58,6 +61,15 @@ jobs:
           echo "Windows SDK is properly installed."
         else
           echo "Windows SDK is not properly installed."
+          exit 1
+        fi
+
+    - name: Verify WindowsKernelModeDriver build tools Installation
+      run: |
+        if choco list --local-only | findstr /C:"windowskernelmodedriver"; then
+          echo "WindowsKernelModeDriver build tools are properly installed."
+        else
+          echo "WindowsKernelModeDriver build tools are not properly installed."
           exit 1
         fi
 

--- a/Driver/i210AVBDriver.vcxproj
+++ b/Driver/i210AVBDriver.vcxproj
@@ -19,7 +19,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Driver</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>WindowsKernelModeDriver</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
     <IntDir>$(Configuration)\$(ProjectName)\</IntDir>
@@ -33,7 +33,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Driver</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>WindowsKernelModeDriver</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <OutDir>$(SolutionDir)$(Configuration)\</OutDir>


### PR DESCRIPTION
Related to #99

Fix the build failure by installing WindowsKernelModeDriver build tools and retargeting the project.

* **Driver/i210AVBDriver.vcxproj**
  - Change `PlatformToolset` to `v142` in both `Debug|x64` and `Release|x64` configurations.
  - Retarget the project to the current Visual Studio tools.

* **.github/workflows/ci.yml**
  - Add a step to install WindowsKernelModeDriver build tools using Chocolatey.
  - Add a step to verify the installation of WindowsKernelModeDriver build tools.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/AVB-Windows/issues/99?shareId=2653fc12-613f-4d98-af5d-53d31fa780ec).