### PR TITLE
Matrix build for Windows 7, Windows 10, and Windows 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,463 @@ permissions:
   issues: write
 
 jobs:
-  build:
+  build-windows-7:
+    runs-on: windows-2016
 
+    env:
+      WDK_IncludePath: C:\Program Files (x86)\Windows Kits\7.1\Include
+
+    outputs:
+      url: ${{ steps.upload_build_logs.outputs.url }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Visual Studio
+      uses: microsoft/setup-msbuild@v2
+
+    - name: Setup NuGet
+      uses: NuGet/setup-nuget@v2
+
+    - name: Restore NuGet packages
+      run: nuget restore AVB_Windows.sln
+
+    - name: Install dependencies
+      run: pip install -r requirements.txt
+
+    - name: Install Windows SDK 7.1
+      run: choco install windows-sdk-7.1 --source=https://chocolatey.org/api/v2/
+
+    - name: Install Windows Driver Kit (WDK) 7.1.0
+      run: choco install windowsdriverkit7.1 --source=https://chocolatey.org/api/v2/
+
+    - name: Install KMDF build tools
+      run: choco install kmdf
+
+    - name: Set executable permissions for verify_wdk_installation.sh
+      run: chmod +x ./scripts/verify_wdk_installation.sh
+
+    - name: Verify Windows Driver Kit (WDK) Installation
+      run: |
+        ./scripts/verify_wdk_installation.sh
+      shell: bash
+
+    - name: Verify Windows SDK Installation
+      run: |
+        if [ -d "C:\Program Files (x86)\Windows Kits\7.1\Include" ]; then
+          echo "Windows SDK is properly installed."
+        else
+          echo "Windows SDK is not properly installed."
+          exit 1
+        fi
+
+    - name: Verify WindowsKernelModeDriver build tools Installation
+      run: |
+        if choco list --local-only | findstr /C:"windowskernelmodedriver"; then
+          echo "WindowsKernelModeDriver build tools are properly installed."
+        else
+          echo "WindowsKernelModeDriver build tools are not properly installed."
+          exit 1
+        fi
+
+    - name: Clean solution
+      run: msbuild AVB_Windows.sln /t:Clean
+
+    - name: Build solution
+      run: msbuild AVB_Windows.sln /p:Configuration=Release > build.log 2>&1
+
+    - name: Ensure log file exists
+      run: |
+        if [ ! -f build.log ]; then
+          echo "No build output captured." > build.log
+        fi
+
+    - name: Run Unit Tests
+      run: |
+        vstest.console.exe Path\To\Your\TestProject.dll
+
+    - name: Run PVS-Studio Analysis
+      run: |
+        # Install PVS-Studio
+        choco install pvs-studio
+
+        # Run analysis
+        "C:\Program Files (x86)\PVS-Studio\PVS-Studio_Cmd.exe" \
+          --target "AVB_Windows.sln" \
+          --configuration "Release" \
+          --output "PVS-Studio.log"
+
+    - name: Check Code Formatting
+      run: |
+        choco install llvm
+
+        clang-format -i -style=file **/*.cpp **/*.h
+
+        git diff --exit-code
+
+    - name: Download Intel Tools
+      run: |
+        curl -o Intel_Ethernet_Controller_I210_Datasheet.pdf https://www.intel.com/content/www/us/en/products/sku/58954/intel-ethernet-controller-i210at/specifications.html
+        curl -o Intel_Ethernet_Adapter_Complete_Driver_Pack.zip https://downloadcenter.intel.com/product/36773/Intel-Ethernet-Adapters
+        curl -o Intel_System_Studio.exe https://www.intel.com/content/www/us/en/developer/tools/system-studio/overview.html
+        curl -o Intel_VTune_Profiler.exe https://www.intel.com/content/www/us/en/developer/tools/oneapi/vtune-profiler.html
+
+    - name: Run Intel Tools
+      run: |
+        # Run Intel System Studio
+        start /wait Intel_System_Studio.exe /S
+
+        # Run Intel VTune Profiler
+        start /wait Intel_VTune_Profiler.exe /S
+
+    - name: Validate AVB Implementation
+      run: |
+        # Run validation scripts using Intel tools
+        python validate_avb.py
+
+    - name: Update SRS
+      run: |
+        # Update the SRS document with new requirements
+        python update_srs.py
+
+    - name: Update Documentation
+      run: |
+        # Update the documentation with new requirements and considerations
+        python update_docs.py
+
+    - name: Update README
+      run: |
+        # Update the README with new requirements and key insights
+        python update_readme.py
+
+    - name: Run Error Detection
+      run: |
+        python scripts/error_detection.py
+
+    - name: Save Errors and Metadata
+      run: |
+        python scripts/error_detection.py > errors_and_metadata.json
+
+    - name: Install PyGithub
+      run: pip install PyGithub
+
+    - name: Upload Build Logs
+      if: failure()
+      id: upload_build_logs
+      uses: actions/upload-artifact@v4
+      with:
+        name: build-logs
+        path: build.log
+        retention-days: 7
+        if-no-files-found: error
+
+    - name: Check for Missing Logs
+      run: |
+        if [ ! -f build.log ]; then
+          echo "No logs found. Skipping error-checking step."
+
+    - name: Run Issue Creation
+      if: failure()
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        COMMIT_SHA: ${{ github.sha }}
+        BUILD_LOGS_LINK: ${{ steps.upload_build_logs.outputs.url }}
+      run: |
+        python scripts/issue_creation.py
+
+    - name: Use Milestones for Releases
+      run: |
+        milestone_title="v1.0 release"
+        milestone_due_date="2023-12-31"
+        milestone_description="Milestone for the v1.0 release"
+        milestone=$(gh api -X POST /repos/${{ github.repository }}/milestones -f title="$milestone_title" -f due_on="$milestone_due_date" -f description="$milestone_description")
+        echo "Milestone created: $milestone"
+
+    - name: Trigger CI Pipeline for Issue Progress
+      run: |
+        issue_status="in progress"
+        if [ "$issue_status" == "in progress" ]; then
+          echo "Triggering CI pipeline for issue progress"
+          # Add logic to trigger CI pipeline
+
+    - name: CI Pipeline Alerts for Failed Builds
+      run: |
+        if [ -f build.log ]; then
+          echo "Build failed. Sending alerts."
+          # Add logic to send alerts via Slack, email, or GitHub notifications
+
+    - name: Use Separate Labels for Environments
+      run: |
+        environment="development"
+        if [ "$environment" == "development" ]; then
+          echo "Labeling as 'in development'"
+          # Add logic to label issues as 'in development'
+        elif [ "$environment" == "staging" ]; then
+          echo "Labeling as 'in staging'"
+          # Add logic to label issues as 'in staging'
+        elif [ "$environment" == "production" ]; then
+          echo "Labeling as 'in production'"
+          # Add logic to label issues as 'in production'
+
+    - name: Enforce Branch Protection Rules
+      run: |
+        branch="main"
+        protection_rules=$(gh api -X GET /repos/${{ github.repository }}/branches/$branch/protection)
+        if [ -z "$protection_rules" ]; then
+          echo "Enforcing branch protection rules"
+          # Add logic to enforce branch protection rules
+
+    - name: Continuous Deployment Labels and Issue Auto-Close
+      run: |
+        deployment_status="success"
+        if [ "$deployment_status" == "success"; then
+          echo "Deployment successful. Auto-closing issues."
+          # Add logic to auto-close issues
+
+    - name: Enforce Issue Templates and CI Requirements
+      run: |
+        issue_template="bug_report.md"
+        if [ -f .github/ISSUE_TEMPLATE/$issue_template ]; then
+          echo "Enforcing issue templates"
+          # Add logic to enforce issue templates
+
+    - name: Integrate Monitoring and Feedback Tools
+      run: |
+        monitoring_tool="Datadog"
+        if [ "$monitoring_tool" == "Datadog" ]; then
+          echo "Integrating Datadog for monitoring and feedback"
+          # Add logic to integrate Datadog
+
+  build-windows-10:
+    runs-on: windows-2019
+
+    env:
+      WDK_IncludePath: C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0
+
+    outputs:
+      url: ${{ steps.upload_build_logs.outputs.url }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Visual Studio
+      uses: microsoft/setup-msbuild@v2
+
+    - name: Setup NuGet
+      uses: NuGet/setup-nuget@v2
+
+    - name: Restore NuGet packages
+      run: nuget restore AVB_Windows.sln
+
+    - name: Install dependencies
+      run: pip install -r requirements.txt
+
+    - name: Install Windows SDK
+      run: choco install windows-sdk-10.1 --source=https://chocolatey.org/api/v2/
+
+    - name: Install Windows Driver Kit (WDK)
+      run: choco install windowsdriverkit10 --source=https://chocolatey.org/api/v2/
+
+    - name: Install KMDF build tools
+      run: choco install kmdf
+
+    - name: Set executable permissions for verify_wdk_installation.sh
+      run: chmod +x ./scripts/verify_wdk_installation.sh
+
+    - name: Verify Windows Driver Kit (WDK) Installation
+      run: |
+        ./scripts/verify_wdk_installation.sh
+      shell: bash
+
+    - name: Verify Windows SDK Installation
+      run: |
+        if [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0" ]; then
+          echo "Windows SDK is properly installed."
+        else
+          echo "Windows SDK is not properly installed."
+          exit 1
+        fi
+
+    - name: Verify WindowsKernelModeDriver build tools Installation
+      run: |
+        if choco list --local-only | findstr /C:"windowskernelmodedriver"; then
+          echo "WindowsKernelModeDriver build tools are properly installed."
+        else
+          echo "WindowsKernelModeDriver build tools are not properly installed."
+          exit 1
+        fi
+
+    - name: Clean solution
+      run: msbuild AVB_Windows.sln /t:Clean
+
+    - name: Build solution
+      run: msbuild AVB_Windows.sln /p:Configuration=Release > build.log 2>&1
+
+    - name: Ensure log file exists
+      run: |
+        if [ ! -f build.log ]; then
+          echo "No build output captured." > build.log
+        fi
+
+    - name: Run Unit Tests
+      run: |
+        vstest.console.exe Path\To\Your\TestProject.dll
+
+    - name: Run PVS-Studio Analysis
+      run: |
+        # Install PVS-Studio
+        choco install pvs-studio
+
+        # Run analysis
+        "C:\Program Files (x86)\PVS-Studio\PVS-Studio_Cmd.exe" \
+          --target "AVB_Windows.sln" \
+          --configuration "Release" \
+          --output "PVS-Studio.log"
+
+    - name: Check Code Formatting
+      run: |
+        choco install llvm
+
+        clang-format -i -style=file **/*.cpp **/*.h
+
+        git diff --exit-code
+
+    - name: Download Intel Tools
+      run: |
+        curl -o Intel_Ethernet_Controller_I210_Datasheet.pdf https://www.intel.com/content/www/us/en/products/sku/58954/intel-ethernet-controller-i210at/specifications.html
+        curl -o Intel_Ethernet_Adapter_Complete_Driver_Pack.zip https://downloadcenter.intel.com/product/36773/Intel-Ethernet-Adapters
+        curl -o Intel_System_Studio.exe https://www.intel.com/content/www/us/en/developer/tools/system-studio/overview.html
+        curl -o Intel_VTune_Profiler.exe https://www.intel.com/content/www/us/en/developer/tools/oneapi/vtune-profiler.html
+
+    - name: Run Intel Tools
+      run: |
+        # Run Intel System Studio
+        start /wait Intel_System_Studio.exe /S
+
+        # Run Intel VTune Profiler
+        start /wait Intel_VTune_Profiler.exe /S
+
+    - name: Validate AVB Implementation
+      run: |
+        # Run validation scripts using Intel tools
+        python validate_avb.py
+
+    - name: Update SRS
+      run: |
+        # Update the SRS document with new requirements
+        python update_srs.py
+
+    - name: Update Documentation
+      run: |
+        # Update the documentation with new requirements and considerations
+        python update_docs.py
+
+    - name: Update README
+      run: |
+        # Update the README with new requirements and key insights
+        python update_readme.py
+
+    - name: Run Error Detection
+      run: |
+        python scripts/error_detection.py
+
+    - name: Save Errors and Metadata
+      run: |
+        python scripts/error_detection.py > errors_and_metadata.json
+
+    - name: Install PyGithub
+      run: pip install PyGithub
+
+    - name: Upload Build Logs
+      if: failure()
+      id: upload_build_logs
+      uses: actions/upload-artifact@v4
+      with:
+        name: build-logs
+        path: build.log
+        retention-days: 7
+        if-no-files-found: error
+
+    - name: Check for Missing Logs
+      run: |
+        if [ ! -f build.log ]; then
+          echo "No logs found. Skipping error-checking step."
+
+    - name: Run Issue Creation
+      if: failure()
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        COMMIT_SHA: ${{ github.sha }}
+        BUILD_LOGS_LINK: ${{ steps.upload_build_logs.outputs.url }}
+      run: |
+        python scripts/issue_creation.py
+
+    - name: Use Milestones for Releases
+      run: |
+        milestone_title="v1.0 release"
+        milestone_due_date="2023-12-31"
+        milestone_description="Milestone for the v1.0 release"
+        milestone=$(gh api -X POST /repos/${{ github.repository }}/milestones -f title="$milestone_title" -f due_on="$milestone_due_date" -f description="$milestone_description")
+        echo "Milestone created: $milestone"
+
+    - name: Trigger CI Pipeline for Issue Progress
+      run: |
+        issue_status="in progress"
+        if [ "$issue_status" == "in progress" ]; then
+          echo "Triggering CI pipeline for issue progress"
+          # Add logic to trigger CI pipeline
+
+    - name: CI Pipeline Alerts for Failed Builds
+      run: |
+        if [ -f build.log ]; then
+          echo "Build failed. Sending alerts."
+          # Add logic to send alerts via Slack, email, or GitHub notifications
+
+    - name: Use Separate Labels for Environments
+      run: |
+        environment="development"
+        if [ "$environment" == "development" ]; then
+          echo "Labeling as 'in development'"
+          # Add logic to label issues as 'in development'
+        elif [ "$environment" == "staging" ]; then
+          echo "Labeling as 'in staging'"
+          # Add logic to label issues as 'in staging'
+        elif [ "$environment" == "production" ]; then
+          echo "Labeling as 'in production'"
+          # Add logic to label issues as 'in production'
+
+    - name: Enforce Branch Protection Rules
+      run: |
+        branch="main"
+        protection_rules=$(gh api -X GET /repos/${{ github.repository }}/branches/$branch/protection)
+        if [ -z "$protection_rules" ]; then
+          echo "Enforcing branch protection rules"
+          # Add logic to enforce branch protection rules
+
+    - name: Continuous Deployment Labels and Issue Auto-Close
+      run: |
+        deployment_status="success"
+        if [ "$deployment_status" == "success"; then
+          echo "Deployment successful. Auto-closing issues."
+          # Add logic to auto-close issues
+
+    - name: Enforce Issue Templates and CI Requirements
+      run: |
+        issue_template="bug_report.md"
+        if [ -f .github/ISSUE_TEMPLATE/$issue_template ]; then
+          echo "Enforcing issue templates"
+          # Add logic to enforce issue templates
+
+    - name: Integrate Monitoring and Feedback Tools
+      run: |
+        monitoring_tool="Datadog"
+        if [ "$monitoring_tool" == "Datadog" ]; then
+          echo "Integrating Datadog for monitoring and feedback"
+          # Add logic to integrate Datadog
+
+  build-windows-11:
     runs-on: windows-latest
 
     env:

--- a/AVB_Windows.sln
+++ b/AVB_Windows.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28729.10
+# Visual Studio Version 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AVDECC", "AVDECC\AVDECC.vcxproj", "{8A2F5A1E-3B2D-4A1B-8A1F-5A1E3B2D4A1B}"
 EndProject
@@ -16,28 +16,50 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
 		Release|x64 = Release|x64
+		Debug|x86 = Debug|x86
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{8A2F5A1E-3B2D-4A1B-8A1F-5A1E3B2D4A1B}.Debug|x64.ActiveCfg = Debug|x64
 		{8A2F5A1E-3B2D-4A1B-8A1F-5A1E3B2D4A1B}.Debug|x64.Build.0 = Debug|x64
 		{8A2F5A1E-3B2D-4A1B-8A1F-5A1E3B2D4A1B}.Release|x64.ActiveCfg = Release|x64
 		{8A2F5A1E-3B2D-4A1B-8A1F-5A1E3B2D4A1B}.Release|x64.Build.0 = Release|x64
+		{8A2F5A1E-3B2D-4A1B-8A1F-5A1E3B2D4A1B}.Debug|x86.ActiveCfg = Debug|x86
+		{8A2F5A1E-3B2D-4A1B-8A1F-5A1E3B2D4A1B}.Debug|x86.Build.0 = Debug|x86
+		{8A2F5A1E-3B2D-4A1B-8A1F-5A1E3B2D4A1B}.Release|x86.ActiveCfg = Release|x86
+		{8A2F5A1E-3B2D-4A1B-8A1F-5A1E3B2D4A1B}.Release|x86.Build.0 = Release|x86
 		{9B3C6A2F-4C3D-5B2E-9B3C-6A2F4C3D5B2E}.Debug|x64.ActiveCfg = Debug|x64
 		{9B3C6A2F-4C3D-5B2E-9B3C-6A2F4C3D5B2E}.Debug|x64.Build.0 = Debug|x64
 		{9B3C6A2F-4C3D-5B2E-9B3C-6A2F4C3D5B2E}.Release|x64.ActiveCfg = Release|x64
 		{9B3C6A2F-4C3D-5B2E-9B3C-6A2F4C3D5B2E}.Release|x64.Build.0 = Release|x64
+		{9B3C6A2F-4C3D-5B2E-9B3C-6A2F4C3D5B2E}.Debug|x86.ActiveCfg = Debug|x86
+		{9B3C6A2F-4C3D-5B2E-9B3C-6A2F4C3D5B2E}.Debug|x86.Build.0 = Debug|x86
+		{9B3C6A2F-4C3D-5B2E-9B3C-6A2F4C3D5B2E}.Release|x86.ActiveCfg = Release|x86
+		{9B3C6A2F-4C3D-5B2E-9B3C-6A2F4C3D5B2E}.Release|x86.Build.0 = Release|x86
 		{AC4D7B3E-5D4E-6C3F-AC4D-7B3E5D4E6C3F}.Debug|x64.ActiveCfg = Debug|x64
 		{AC4D7B3E-5D4E-6C3F-AC4D-7B3E5D4E6C3F}.Debug|x64.Build.0 = Debug|x64
 		{AC4D7B3E-5D4E-6C3F-AC4D-7B3E5D4E6C3F}.Release|x64.ActiveCfg = Release|x64
 		{AC4D7B3E-5D4E-6C3F-AC4D-7B3E5D4E6C3F}.Release|x64.Build.0 = Release|x64
+		{AC4D7B3E-5D4E-6C3F-AC4D-7B3E5D4E6C3F}.Debug|x86.ActiveCfg = Debug|x86
+		{AC4D7B3E-5D4E-6C3F-AC4D-7B3E5D4E6C3F}.Debug|x86.Build.0 = Debug|x86
+		{AC4D7B3E-5D4E-6C3F-AC4D-7B3E5D4E6C3F}.Release|x86.ActiveCfg = Release|x86
+		{AC4D7B3E-5D4E-6C3F-AC4D-7B3E5D4E6C3F}.Release|x86.Build.0 = Release|x86
 		{BD5E8C4F-6E5F-7D4G-BD5E-8C4F6E5F7D4G}.Debug|x64.ActiveCfg = Debug|x64
 		{BD5E8C4F-6E5F-7D4G-BD5E-8C4F6E5F7D4G}.Debug|x64.Build.0 = Debug|x64
 		{BD5E8C4F-6E5F-7D4G-BD5E-8C4F6E5F7D4G}.Release|x64.ActiveCfg = Release|x64
 		{BD5E8C4F-6E5F-7D4G-BD5E-8C4F6E5F7D4G}.Release|x64.Build.0 = Release|x64
+		{BD5E8C4F-6E5F-7D4G-BD5E-8C4F6E5F7D4G}.Debug|x86.ActiveCfg = Debug|x86
+		{BD5E8C4F-6E5F-7D4G-BD5E-8C4F6E5F7D4G}.Debug|x86.Build.0 = Debug|x86
+		{BD5E8C4F-6E5F-7D4G-BD5E-8C4F6E5F7D4G}.Release|x86.ActiveCfg = Release|x86
+		{BD5E8C4F-6E5F-7D4G-BD5E-8C4F6E5F7D4G}.Release|x86.Build.0 = Release|x86
 		{CE6F9D5G-7F6H-8E5I-CE6F-9D5G7F6H8E5I}.Debug|x64.ActiveCfg = Debug|x64
 		{CE6F9D5G-7F6H-8E5I-CE6F-9D5G7F6H8E5I}.Debug|x64.Build.0 = Debug|x64
 		{CE6F9D5G-7F6H-8E5I-CE6F-9D5G7F6H8E5I}.Release|x64.ActiveCfg = Release|x64
 		{CE6F9D5G-7F6H-8E5I-CE6F-9D5G7F6H8E5I}.Release|x64.Build.0 = Release|x64
+		{CE6F9D5G-7F6H-8E5I-CE6F-9D5G7F6H8E5I}.Debug|x86.ActiveCfg = Debug|x86
+		{CE6F9D5G-7F6H-8E5I-CE6F-9D5G7F6H8E5I}.Debug|x86.Build.0 = Debug|x86
+		{CE6F9D5G-7F6H-8E5I-CE6F-9D5G7F6H8E5I}.Release|x86.ActiveCfg = Release|x86
+		{CE6F9D5G-7F6H-8E5I-CE6F-9D5G7F6H8E5I}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/AVDECC/AVDECC.vcxproj
+++ b/AVDECC/AVDECC.vcxproj
@@ -9,6 +9,14 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x86">
+      <Configuration>Debug</Configuration>
+      <Platform>x86</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x86">
+      <Configuration>Release</Configuration>
+      <Platform>x86</Platform>
+    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{8A2F5A1E-3B2D-4A1B-8A1F-5A1E3B2D4A1B}</ProjectGuid>
@@ -43,6 +51,33 @@
       <Command>copy "$(OutDir)$(TargetName).exe" "$(SolutionDir)build.log"</Command>
     </PostBuildEvent>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\</IntDir>
+    <TargetName>$(ProjectName)</TargetName>
+    <GenerateManifest>false</GenerateManifest>
+    <PostBuildEvent>
+      <Command>copy "$(OutDir)$(TargetName).exe" "$(SolutionDir)build.log"</Command>
+    </PostBuildEvent>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\</IntDir>
+    <TargetName>$(ProjectName)</TargetName>
+    <GenerateManifest>false</GenerateManifest>
+    <PostBuildEvent>
+      <Command>copy "$(OutDir)$(TargetName).exe" "$(SolutionDir)build.log"</Command>
+    </PostBuildEvent>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -52,6 +87,12 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x86'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
@@ -75,6 +116,38 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_WINSOCK_DEPRECATED_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>false</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_WINSOCK_DEPRECATED_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>MaxSpeed</Optimization>

--- a/AVTP/AVTP.vcxproj
+++ b/AVTP/AVTP.vcxproj
@@ -9,6 +9,14 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x86">
+      <Configuration>Debug</Configuration>
+      <Platform>x86</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x86">
+      <Configuration>Release</Configuration>
+      <Platform>x86</Platform>
+    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{9B3C6A2F-4C3D-5B2E-9B3C-6A2F4C3D5B2E}</ProjectGuid>
@@ -43,6 +51,33 @@
       <Command>copy "$(OutDir)$(TargetName).exe" "$(SolutionDir)build.log"</Command>
     </PostBuildEvent>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\</IntDir>
+    <TargetName>$(ProjectName)</TargetName>
+    <GenerateManifest>false</GenerateManifest>
+    <PostBuildEvent>
+      <Command>copy "$(OutDir)$(TargetName).exe" "$(SolutionDir)build.log"</Command>
+    </PostBuildEvent>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\</IntDir>
+    <TargetName>$(ProjectName)</TargetName>
+    <GenerateManifest>false</GenerateManifest>
+    <PostBuildEvent>
+      <Command>copy "$(OutDir)$(TargetName).exe" "$(SolutionDir)build.log"</Command>
+    </PostBuildEvent>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -52,6 +87,12 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x86'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
@@ -75,6 +116,38 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_WINSOCK_DEPRECATED_NO_WARNINGS;WIN32_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>false</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_WINSOCK_DEPRECATED_NO_WARNINGS;WIN32_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>MaxSpeed</Optimization>

--- a/Driver/i210AVBDriver.vcxproj
+++ b/Driver/i210AVBDriver.vcxproj
@@ -9,6 +9,14 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x86">
+      <Configuration>Debug</Configuration>
+      <Platform>x86</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x86">
+      <Configuration>Release</Configuration>
+      <Platform>x86</Platform>
+    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{BD5E8C4F-6E5F-7D4G-BD5E-8C4F6E5F7D4G}</ProjectGuid>
@@ -45,6 +53,35 @@
     </PostBuildEvent>
     <AdditionalIncludeDirectories>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)include;$(SolutionDir)Driver\include;$(SolutionDir)Driver\ntddk;$(WDK_IncludePath);$(WDK_IncludePath)\km;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'" Label="Configuration">
+    <ConfigurationType>Driver</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\</IntDir>
+    <TargetName>$(ProjectName)</TargetName>
+    <GenerateManifest>false</GenerateManifest>
+    <PostBuildEvent>
+      <Command>copy "$(OutDir)$(TargetName).exe" "$(SolutionDir)build.log"</Command>
+    </PostBuildEvent>
+    <AdditionalIncludeDirectories>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)include;$(SolutionDir)Driver\include;$(SolutionDir)Driver\ntddk;$(WDK_IncludePath);$(WDK_IncludePath)\km;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'" Label="Configuration">
+    <ConfigurationType>Driver</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\</IntDir>
+    <TargetName>$(ProjectName)</TargetName>
+    <GenerateManifest>false</GenerateManifest>
+    <PostBuildEvent>
+      <Command>copy "$(OutDir)$(TargetName).exe" "$(SolutionDir)build.log"</Command>
+    </PostBuildEvent>
+    <AdditionalIncludeDirectories>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)include;$(SolutionDir)Driver\include;$(SolutionDir)Driver\ntddk;$(WDK_IncludePath);$(WDK_IncludePath)\km;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -54,6 +91,12 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x86'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
@@ -77,6 +120,38 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_WINSOCK_DEPRECATED_NO_WARNINGS;WIN32_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>false</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_WINSOCK_DEPRECATED_NO_WARNINGS;WIN32_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>MaxSpeed</Optimization>

--- a/GUI/AVBTool.vcxproj
+++ b/GUI/AVBTool.vcxproj
@@ -9,6 +9,14 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x86">
+      <Configuration>Debug</Configuration>
+      <Platform>x86</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x86">
+      <Configuration>Release</Configuration>
+      <Platform>x86</Platform>
+    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{CE6F9D5G-7F6H-8E5I-CE6F-9D5G7F6H8E5I}</ProjectGuid>
@@ -43,6 +51,33 @@
       <Command>copy "$(OutDir)$(TargetName).exe" "$(SolutionDir)build.log"</Command>
     </PostBuildEvent>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\</IntDir>
+    <TargetName>$(ProjectName)</TargetName>
+    <GenerateManifest>false</GenerateManifest>
+    <PostBuildEvent>
+      <Command>copy "$(OutDir)$(TargetName).exe" "$(SolutionDir)build.log"</Command>
+    </PostBuildEvent>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\</IntDir>
+    <TargetName>$(ProjectName)</TargetName>
+    <GenerateManifest>false</GenerateManifest>
+    <PostBuildEvent>
+      <Command>copy "$(OutDir)$(TargetName).exe" "$(SolutionDir)build.log"</Command>
+    </PostBuildEvent>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -52,6 +87,12 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x86'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
@@ -75,6 +116,38 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_WINSOCK_DEPRECATED_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>false</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_WINSOCK_DEPRECATED_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>MaxSpeed</Optimization>

--- a/gPTP/gPTP.vcxproj
+++ b/gPTP/gPTP.vcxproj
@@ -9,6 +9,14 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x86">
+      <Configuration>Debug</Configuration>
+      <Platform>x86</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x86">
+      <Configuration>Release</Configuration>
+      <Platform>x86</Platform>
+    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{AC4D7B3E-5D4E-6C3F-AC4D-7B3E5D4E6C3F}</ProjectGuid>
@@ -43,6 +51,33 @@
       <Command>copy "$(OutDir)$(TargetName).exe" "$(SolutionDir)build.log"</Command>
     </PostBuildEvent>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\</IntDir>
+    <TargetName>$(ProjectName)</TargetName>
+    <GenerateManifest>false</GenerateManifest>
+    <PostBuildEvent>
+      <Command>copy "$(OutDir)$(TargetName).exe" "$(SolutionDir)build.log"</Command>
+    </PostBuildEvent>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\</IntDir>
+    <TargetName>$(ProjectName)</TargetName>
+    <GenerateManifest>false</GenerateManifest>
+    <PostBuildEvent>
+      <Command>copy "$(OutDir)$(TargetName).exe" "$(SolutionDir)build.log"</Command>
+    </PostBuildEvent>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -52,6 +87,12 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x86'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
@@ -75,6 +116,38 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_WINSOCK_DEPRECATED_NO_WARNINGS;WIN32_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>false</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_WINSOCK_DEPRECATED_NO_WARNINGS;WIN32_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>MaxSpeed</Optimization>


### PR DESCRIPTION
Related to #104

Add support for building, testing, and validating the project on Windows 7, Windows 10, and Windows 11.

* **Update Visual Studio Solution File (`AVB_Windows.sln`)**
  - Change Visual Studio version to 2015 for Windows 7 compatibility.
  - Add configurations for x86 architecture.

* **Update Project Files**
  - Add configurations for x86 architecture in `AVDECC/AVDECC.vcxproj`, `AVTP/AVTP.vcxproj`, `gPTP/gPTP.vcxproj`, `Driver/i210AVBDriver.vcxproj`, and `GUI/AVBTool.vcxproj`.

* **Update CI Pipeline (`.github/workflows/ci.yml`)**
  - Add separate jobs for Windows 7, Windows 10, and Windows 11.
  - Use Windows SDK 7.1 and WDK 7.1.0 for Windows 7 job.
  - Update `runs-on` attribute for each job to target the appropriate Windows version.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/AVB-Windows/issues/104?shareId=d05604dc-0be3-473c-ae7c-9d08887e3bf9).