### PR TITLE
Fix GITHUB_TOKEN environment variable in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,6 +402,8 @@ jobs:
 
     - name: Check for Log File Existence
       if: failure()
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       id: check_log_file_existence
       run: |
         python scripts/error_detection.py --check-logs

--- a/scripts/error_detection.py
+++ b/scripts/error_detection.py
@@ -57,7 +57,7 @@ def save_errors_and_metadata(errors, metadata, output_path, log_link):
 def update_issue_labels(issue, labels):
     issue_labels = [label.name for label in issue.labels]
     for label in labels:
-        if label not in issue_labels, issue_labels.append(label)
+        if label not in issue_labels: issue_labels.append(label)
     issue.edit(labels=issue_labels)
 
 def verify_build_logs_link(log_link):

--- a/scripts/error_detection.py
+++ b/scripts/error_detection.py
@@ -74,6 +74,12 @@ def create_dynamic_path_string(log_paths):
     existing_logs = [log_path for log_path in log_paths if check_log_file_existence(log_path)]
     return " ".join(existing_logs)
 
+def get_github_token():
+    token = os.environ.get('GITHUB_TOKEN')
+    if not token:
+        raise ValueError("GITHUB_TOKEN environment variable not set")
+    return token
+
 def main():
     log_paths = [
         "build.log",
@@ -101,9 +107,7 @@ def main():
         print(f"Errors and metadata saved to {output_path}")
 
     # Automate status updates using labels based on CI pipeline progress
-    token = os.environ.get('GITHUB_TOKEN')
-    if not token:
-        raise ValueError("GITHUB_TOKEN environment variable not set")
+    token = get_github_token()
 
     g = Github(token)
     repo_name = "zarfld/AVB-Windows"


### PR DESCRIPTION
Related to #112

Add handling for `GITHUB_TOKEN` environment variable in CI process on Windows 10.

* **scripts/error_detection.py**
  - Add a new function `get_github_token` to retrieve the `GITHUB_TOKEN` environment variable.
  - Replace the direct access to `GITHUB_TOKEN` with a call to `get_github_token` in the `main` function.
  - Update the `main` function to call `get_github_token` before using the token.

* **.github/workflows/ci.yml**
  - Add the `GITHUB_TOKEN` environment variable to the `Check for Log File Existence` step in the `build-windows-10` job.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/AVB-Windows/issues/112?shareId=53cc9f01-e98e-477e-8eb5-64d983ad982d).