### PR TITLE
Handle KMDF as optional in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -559,7 +559,7 @@ jobs:
         elif [ "$environment" == "staging" ]; then
           echo "Labeling as 'in staging'"
           # Add logic to label issues as 'in staging'
-        elif [ "$environment" == "production"; then
+        elif [ "$environment" == "production" ]; then
           echo "Labeling as 'in production'"
           # Add logic to label issues as 'in production'
         fi
@@ -859,7 +859,7 @@ jobs:
         elif [ "$environment" == "staging" ]; then
           echo "Labeling as 'in staging'"
           # Add logic to label issues as 'in staging'
-        elif [ "$environment" == "production"; then
+        elif [ "$environment" == "production" ]; then
           echo "Labeling as 'in production'"
           # Add logic to label issues as 'in production'
         fi

--- a/scripts/verify_wdk_installation.sh
+++ b/scripts/verify_wdk_installation.sh
@@ -43,3 +43,10 @@ else
   echo "Windows SDK is not properly installed."
   exit 1
 fi
+
+# Check if KMDF 1.31 is installed
+if [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\km\wdf" ]; then
+  echo "KMDF 1.31 is properly installed."
+else
+  echo "KMDF 1.31 is not properly installed. Continuing without KMDF."
+fi


### PR DESCRIPTION
Related to #120

Modify `scripts/verify_wdk_installation.sh` to handle KMDF 1.31 as optional.

* Add a check for KMDF 1.31 installation and log a warning if it is not found, but do not exit the script.
* Ensure the script continues to the next steps even if KMDF 1.31 is not installed.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/AVB-Windows/issues/120?shareId=37f4a40e-b0e6-419a-858f-102995ab2436).