### PR TITLE
Handle KMDF as optional in CI pipeline

### DIFF
--- a/scripts/verify_wdk_installation.sh
+++ b/scripts/verify_wdk_installation.sh
@@ -48,14 +48,12 @@ fi
 if [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\kmdf\1.31" ]; then
   echo "KMDF 1.31 is properly installed for Windows 10."
 else
-  echo "KMDF 1.31 is not properly installed for Windows 10."
-  exit 1
+  echo "Warning: KMDF 1.31 is not properly installed for Windows 10."
 fi
 
 # Verify the installation of KMDF 1.33 for Windows 11
 if [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\kmdf\1.33" ]; then
   echo "KMDF 1.33 is properly installed for Windows 11."
 else
-  echo "KMDF 1.33 is not properly installed for Windows 11."
-  exit 1
+  echo "Warning: KMDF 1.33 is not properly installed for Windows 11."
 fi


### PR DESCRIPTION
Related to #120

Modify `scripts/verify_wdk_installation.sh` to handle KMDF as optional.

* Log a warning if KMDF 1.31 is not found instead of exiting with code 1.
* Log a warning if KMDF 1.33 is not found instead of exiting with code 1.
* Ensure the script continues execution even if KMDF 1.31 or 1.33 is not installed.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/AVB-Windows/issues/120?shareId=5ae2dead-d337-46c1-8439-7317b60dcba0).