### PR TITLE
Fix parse error in Verify Windows SDK Installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,12 +57,12 @@ jobs:
 
     - name: Verify Windows SDK Installation
       run: |
-        if [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0" ]; then
+        if (Test-Path "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0") {
           echo "Windows SDK is properly installed."
-        else
+        } else {
           echo "Windows SDK is not properly installed."
           exit 1
-        fi
+        }
 
     - name: Verify WindowsKernelModeDriver build tools Installation
       run: |
@@ -345,12 +345,12 @@ jobs:
 
     - name: Verify Windows SDK Installation
       run: |
-        if [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0" ]; then
+        if (Test-Path "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0") {
           echo "Windows SDK is properly installed."
-        else
+        } else {
           echo "Windows SDK is not properly installed."
           exit 1
-        fi
+        }
 
     - name: Verify WindowsKernelModeDriver build tools Installation
       run: |

--- a/scripts/verify_wdk_installation.sh
+++ b/scripts/verify_wdk_installation.sh
@@ -4,56 +4,56 @@
 export WDK_IncludePath="C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0"
 
 # Check if the WDK files are present in the correct installation path
-if [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0" ]; then
+if (Test-Path "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0") {
   echo "WDK files are present in the correct installation path."
-else
+} else {
   echo "WDK files are not present in the correct installation path."
   exit 1
-fi
+}
 
 # Check for the presence of ntddk.h in the correct installation path
-if [ -f "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\km\ntddk.h" ]; then
+if (Test-Path "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\km\ntddk.h") {
   echo "ntddk.h is present in the correct installation path."
-else
+} else {
   echo "ntddk.h is not present in the correct installation path."
   exit 1
-fi
+}
 
 # Check if the WDK_IncludePath environment variable is set
-if [ -z "$WDK_IncludePath" ]; then
+if ($env:WDK_IncludePath -eq $null) {
   echo "WDK_IncludePath environment variable is not set."
   exit 1
-else
-  echo "WDK_IncludePath is set to: $WDK_IncludePath"
-fi
+} else {
+  echo "WDK_IncludePath is set to: $env:WDK_IncludePath"
+}
 
 # Log the output for troubleshooting
 echo "WDK is properly installed."
 
 # Provide debugging information on the path and files for Driver/i210AVBDriver.cpp
 echo "Debugging information for Driver/i210AVBDriver.cpp:"
-echo "Path: $(realpath Driver/i210AVBDriver.cpp)"
+echo "Path: $(Get-Item -Path Driver/i210AVBDriver.cpp).FullName"
 echo "Files in directory:"
-ls -l Driver/
+Get-ChildItem -Path Driver/
 
 # Check if the Windows SDK is installed and compatible with the WDK
-if [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0" ]; then
+if (Test-Path "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0") {
   echo "Windows SDK is properly installed."
-else
+} else {
   echo "Windows SDK is not properly installed."
   exit 1
-fi
+}
 
 # Verify the installation of KMDF 1.31 for Windows 10
-if [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\kmdf\1.31" ]; then
+if (Test-Path "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\kmdf\1.31") {
   echo "KMDF 1.31 is properly installed for Windows 10."
-else
+} else {
   echo "Warning: KMDF 1.31 is not properly installed for Windows 10."
-fi
+}
 
 # Verify the installation of KMDF 1.33 for Windows 11
-if [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\kmdf\1.33" ]; then
+if (Test-Path "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\kmdf\1.33") {
   echo "KMDF 1.33 is properly installed for Windows 11."
-else
+} else {
   echo "Warning: KMDF 1.33 is not properly installed for Windows 11."
-fi
+}


### PR DESCRIPTION
Related to #123

Fix the parse error in the "Verify Windows SDK Installation" script by updating the syntax to PowerShell.

* **scripts/verify_wdk_installation.sh**
  - Update the `if` statements to use PowerShell syntax with `Test-Path`.
  - Replace bash-style `if` statements with PowerShell-style `if` statements.
  - Update the `else` statements to use PowerShell syntax for outputting messages and exiting.
  - Update commands to use PowerShell syntax for path and file checks.

* **.github/workflows/ci.yml**
  - Update the `Verify Windows SDK Installation` step to use PowerShell syntax.
  - Replace bash-style `if` statements with PowerShell-style `if` statements.
  - Update the `else` statements to use PowerShell syntax for outputting messages and exiting.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/AVB-Windows/issues/123?shareId=54de7ef8-5ac7-402d-b499-56cc2db77e2b).