### PR TITLE
Fix verification scripts for Windows SDK and KMDF installations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,22 +60,14 @@ jobs:
     - name: Verify Windows SDK Installation
       continue-on-error: true
       run: |
-        if [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0" ]; then
-          echo "Windows SDK is properly installed."
-        else
-          echo "Windows SDK is not properly installed."
-          exit 1
-        fi
+        ./scripts/verify_windows_sdk_installation.sh
+      shell: bash
 
     - name: Verify WindowsKernelModeDriver build tools Installation
       continue-on-error: true
       run: |
-        if [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0" ]; then
-          echo "Windows SDK is properly installed."
-        else
-          echo "Windows SDK is not properly installed."
-          exit 1
-        fi
+        ./scripts/verify_kmdf_installation.sh
+      shell: bash
 
     - name: Clean solution
       run: msbuild AVB_Windows.sln /t:Clean
@@ -351,22 +343,14 @@ jobs:
     - name: Verify Windows SDK Installation
       continue-on-error: true
       run: |
-        if [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0" ]; then
-          echo "Windows SDK is properly installed."
-        else
-          echo "Windows SDK is not properly installed."
-          exit 1
-        fi
+        ./scripts/verify_windows_sdk_installation.sh
+      shell: bash
 
     - name: Verify WindowsKernelModeDriver build tools Installation
       continue-on-error: true
       run: |
-        if [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0" ]; then
-          echo "Windows SDK is properly installed."
-        else
-          echo "Windows SDK is not properly installed."
-          exit 1
-        fi
+        ./scripts/verify_kmdf_installation.sh
+      shell: bash
 
     - name: Clean solution
       run: msbuild AVB_Windows.sln /t:Clean

--- a/scripts/verify_kmdf_installation.sh
+++ b/scripts/verify_kmdf_installation.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Check if KMDF 1.31 is properly installed for Windows 10
+if [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\kmdf\1.31" ]; then
+  echo "KMDF 1.31 is properly installed for Windows 10."
+else
+  echo "Warning: KMDF 1.31 is not properly installed for Windows 10."
+fi
+
+# Check if KMDF 1.33 is properly installed for Windows 11
+if [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\kmdf\1.33" ]; then
+  echo "KMDF 1.33 is properly installed for Windows 11."
+else
+  echo "Warning: KMDF 1.33 is not properly installed for Windows 11."
+fi
+
+# Log the output for troubleshooting
+echo "KMDF installation verification completed."

--- a/scripts/verify_windows_sdk_installation.sh
+++ b/scripts/verify_windows_sdk_installation.sh
@@ -2,6 +2,24 @@
 
 # Check if the Windows SDK files are present in the correct installation path
 if [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0" ]; then
+  echo "Windows SDK files are present in the correct installation path. (10.0.22621.0)"
+elif [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.1.18362.1" ]; then
+  echo "Windows SDK files are present in the correct installation path. (10.1.18362.1)"
+elif [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.1.17763.1" ]; then
+  echo "Windows SDK files are present in the correct installation path. (10.1.17763.1)"
+elif [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.1.17134.12" ]; then
+  echo "Windows SDK files are present in the correct installation path. (10.1.17134.12)"
+elif [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.1.15063.468" ]; then
+  echo "Windows SDK files are present in the correct installation path. (10.1.15063.468)"
+elif [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.1.10586.15" ]; then
+  echo "Windows SDK files are present in the correct installation path. (10.1.10586.15)"
+else
+  echo "Windows SDK files are not present in the correct installation path."
+  exit 1
+fi
+
+# Check if the Windows SDK files are present in the correct installation path
+if [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0" ]; then
   echo "Windows SDK files are present in the correct installation path."
 else
   echo "Windows SDK files are not present in the correct installation path."

--- a/scripts/verify_windows_sdk_installation.sh
+++ b/scripts/verify_windows_sdk_installation.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Check if the Windows SDK files are present in the correct installation path
+if [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0" ]; then
+  echo "Windows SDK files are present in the correct installation path."
+else
+  echo "Windows SDK files are not present in the correct installation path."
+  exit 1
+fi
+
+# Log the output for troubleshooting
+echo "Windows SDK is properly installed."


### PR DESCRIPTION
Related to #126

Add verification scripts for Windows SDK and KMDF installations and update CI workflow.

* **Add `scripts/verify_windows_sdk_installation.sh`**
  - Check if Windows SDK files are present in the correct installation path.
  - Log the output for troubleshooting.

* **Add `scripts/verify_kmdf_installation.sh`**
  - Check if KMDF 1.31 and 1.33 are properly installed.
  - Log the output for troubleshooting.

* **Update `.github/workflows/ci.yml`**
  - Replace inline shell commands for verifying Windows SDK and KMDF installations with calls to the new verification scripts.
  - Update the `Verify Windows SDK Installation` step to use `scripts/verify_windows_sdk_installation.sh`.
  - Update the `Verify WindowsKernelModeDriver build tools Installation` step to use `scripts/verify_kmdf_installation.sh`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/AVB-Windows/issues/126?shareId=c964ebda-e2bc-48ea-b057-7cd328f63eaf).