### PR TITLE
Install both Windows SDK versions 10 and 10.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: windows-2022
 
     env:
-      WDK_IncludePath: C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0
+      WDK_IncludePath: C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0;C:\Program Files (x86)\Windows Kits\10.1\Include\10.1.18362.1
 
     outputs:
       url: ${{ steps.upload_build_logs.outputs.url }}
@@ -38,7 +38,10 @@ jobs:
       run: pip install -r requirements.txt > install_dependencies.log 2>&1
 
     - name: Install Windows SDK
-      run: choco install windows-sdk-10.1 --source=https://chocolatey.org/api/v2/ > install_windows_sdk.log 2>&1
+      run: choco install windows-sdk-10 --source=https://chocolatey.org/api/v2/ > install_windows_sdk.log 2>&1
+
+    - name: Install Windows SDK 10.1
+      run: choco install windows-sdk-10.1 --source=https://chocolatey.org/api/v2/ > install_windows_sdk_10.1.log 2>&1
 
     - name: Install Windows Driver Kit (WDK)
       run: choco install windowsdriverkit10 --source=https://chocolatey.org/api/v2/ > install_windows_driver_kit.log 2>&1
@@ -188,6 +191,16 @@ jobs:
         retention-days: 7
         if-no-files-found: error
 
+    - name: Upload Install Windows SDK 10.1 Logs
+      if: failure()
+      id: upload_install_windows_sdk_10.1_logs
+      uses: actions/upload-artifact@v4
+      with:
+        name: install-windows-sdk-10.1-logs
+        path: install_windows_sdk_10.1.log
+        retention-days: 7
+        if-no-files-found: error
+
     - name: Upload Install Windows Driver Kit Logs
       if: failure()
       id: upload_install_windows_driver_kit_logs
@@ -300,7 +313,7 @@ jobs:
     runs-on: windows-latest
 
     env:
-      WDK_IncludePath: C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0
+      WDK_IncludePath: C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0;C:\Program Files (x86)\Windows Kits\10.1\Include\10.1.18362.1
 
     outputs:
       url: ${{ steps.upload_build_logs.outputs.url }}
@@ -322,7 +335,10 @@ jobs:
       run: pip install -r requirements.txt > install_dependencies.log 2>&1
 
     - name: Install Windows SDK
-      run: choco install windows-sdk-10.1 --source=https://chocolatey.org/api/v2/ > install_windows_sdk.log 2>&1
+      run: choco install windows-sdk-10 --source=https://chocolatey.org/api/v2/ > install_windows_sdk.log 2>&1
+
+    - name: Install Windows SDK 10.1
+      run: choco install windows-sdk-10.1 --source=https://chocolatey.org/api/v2/ > install_windows_sdk_10.1.log 2>&1
 
     - name: Install Windows Driver Kit (WDK)
       run: choco install windowsdriverkit10 --source=https://chocolatey.org/api/v2/ > install_windows_driver_kit.log 2>&1
@@ -481,6 +497,16 @@ jobs:
       with:
         name: install-windows-sdk-logs
         path: install_windows_sdk.log
+        retention-days: 7
+        if-no-files-found: error
+
+    - name: Upload Install Windows SDK 10.1 Logs
+      if: failure()
+      id: upload_install_windows_sdk_10.1_logs
+      uses: actions/upload-artifact@v4
+      with:
+        name: install-windows-sdk-10.1-logs
+        path: install_windows_sdk_10.1.log
         retention-days: 7
         if-no-files-found: error
 

--- a/scripts/verify_wdk_installation.sh
+++ b/scripts/verify_wdk_installation.sh
@@ -38,7 +38,9 @@ ls -l Driver/
 
 # Check if the Windows SDK is installed and compatible with the WDK
 if [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0" ]; then
-  echo "Windows SDK is properly installed."
+  echo "Windows SDK 10 is properly installed."
+elif [ -d "C:\Program Files (x86)\Windows Kits\10.1\Include\10.1.18362.1" ]; then
+  echo "Windows SDK 10.1 is properly installed."
 else
   echo "Windows SDK is not properly installed."
   exit 1
@@ -57,3 +59,6 @@ if [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\kmdf\1.33" 
 else
   echo "Warning: KMDF 1.33 is not properly installed for Windows 11."
 fi
+
+# Log the output for troubleshooting
+echo "WDK installation verification completed."

--- a/scripts/verify_windows_sdk_installation.sh
+++ b/scripts/verify_windows_sdk_installation.sh
@@ -3,28 +3,20 @@
 # Check if the Windows SDK files are present in the correct installation path
 if [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0" ]; then
   echo "Windows SDK files are present in the correct installation path. (10.0.22621.0)"
-elif [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.1.18362.1" ]; then
+elif [ -d "C:\Program Files (x86)\Windows Kits\10.1\Include\10.1.18362.1" ]; then
   echo "Windows SDK files are present in the correct installation path. (10.1.18362.1)"
-elif [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.1.17763.1" ]; then
+elif [ -d "C:\Program Files (x86)\Windows Kits\10.1\Include\10.1.17763.1" ]; then
   echo "Windows SDK files are present in the correct installation path. (10.1.17763.1)"
-elif [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.1.17134.12" ]; then
+elif [ -d "C:\Program Files (x86)\Windows Kits\10.1\Include\10.1.17134.12" ]; then
   echo "Windows SDK files are present in the correct installation path. (10.1.17134.12)"
-elif [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.1.15063.468" ]; then
+elif [ -d "C:\Program Files (x86)\Windows Kits\10.1\Include\10.1.15063.468" ]; then
   echo "Windows SDK files are present in the correct installation path. (10.1.15063.468)"
-elif [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.1.10586.15" ]; then
+elif [ -d "C:\Program Files (x86)\Windows Kits\10.1\Include\10.1.10586.15" ]; then
   echo "Windows SDK files are present in the correct installation path. (10.1.10586.15)"
 else
   echo "Windows SDK files are not present in the correct installation path."
   exit 1
 fi
 
-# Check if the Windows SDK files are present in the correct installation path
-if [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0" ]; then
-  echo "Windows SDK files are present in the correct installation path."
-else
-  echo "Windows SDK files are not present in the correct installation path."
-  exit 1
-fi
-
 # Log the output for troubleshooting
-echo "Windows SDK is properly installed."
+echo "Windows SDK installation verification completed."


### PR DESCRIPTION
Related to #130

Add support for installing both Windows SDK versions 10 and 10.1 in the CI pipeline.

* **scripts/verify_windows_sdk_installation.sh**
  - Add checks for Windows SDK version 10.1.
  - Log the output for troubleshooting.

* **scripts/verify_wdk_installation.sh**
  - Add checks for Windows SDK version 10.1.
  - Log the output for troubleshooting.

* **.github/workflows/ci.yml**
  - Install both Windows SDK versions 10 and 10.1 using Chocolatey in `build-windows-10` and `build-windows-11` jobs.
  - Set `WDK_IncludePath` environment variable for both Windows SDK versions 10 and 10.1.
  - Upload logs for Windows SDK 10.1 installation.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/AVB-Windows/issues/130?shareId=377793ff-75c7-451b-9303-ec497c4dd695).