### PR TITLE
Fix CI pipeline by adding GitHub Actions permissions check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,16 @@ jobs:
         ./scripts/verify_kmdf_installation.sh
       shell: bash
 
+    - name: Check GitHub Actions Permissions
+      run: |
+        echo "Checking GitHub Actions permissions..."
+        if [ -z "${{ github.token }}" ]; then
+          echo "GitHub Actions token is not set. Please check repository settings."
+          exit 1
+        else
+          echo "GitHub Actions token is set."
+        fi
+
     - name: Clean solution
       run: msbuild AVB_Windows.sln /t:Clean
 
@@ -367,6 +377,16 @@ jobs:
       run: |
         ./scripts/verify_kmdf_installation.sh
       shell: bash
+
+    - name: Check GitHub Actions Permissions
+      run: |
+        echo "Checking GitHub Actions permissions..."
+        if [ -z "${{ github.token }}" ]; then
+          echo "GitHub Actions token is not set. Please check repository settings."
+          exit 1
+        else
+          echo "GitHub Actions token is set."
+        fi
 
     - name: Clean solution
       run: msbuild AVB_Windows.sln /t:Clean

--- a/README.md
+++ b/README.md
@@ -521,3 +521,16 @@ To ensure compatibility with the appropriate Windows versions, update the CI pip
    - Update the `scripts/verify_wdk_installation.sh` script to verify the installation of KMDF 1.31 for Windows 10 and KMDF 1.33 for Windows 11.
 
 By following these steps, you can ensure that the CI pipeline is updated to use the correct KMDF versions for Windows 10 and Windows 11, ensuring compatibility and successful builds.
+
+### Setting Up GitHub Actions Permissions
+
+To ensure that the CI pipeline runs jobs as expected, it is important to set up GitHub Actions permissions in the repository settings. Follow these steps:
+
+1. Navigate to the repository on GitHub.
+2. Click on the "Settings" tab.
+3. In the left sidebar, click on "Actions".
+4. Under "Actions permissions", ensure that "Allow all actions and reusable workflows" is selected.
+5. Under "Workflow permissions", select "Read and write permissions".
+6. Click "Save" to apply the changes.
+
+By setting up the appropriate permissions, you ensure that the CI pipeline has the necessary access to run jobs and interact with the repository.


### PR DESCRIPTION
Related to #132

Add a section in `README.md` to explain the need for GitHub repository permissions for CI.

Add a step in `.github/workflows/ci.yml` to check for GitHub Actions permissions in the repository settings.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/AVB-Windows/issues/132?shareId=0b20d6e9-3255-40be-befb-a45276b27497).