### PR TITLE
Fix GitHub Actions permissions error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,12 +75,12 @@ jobs:
     - name: Check GitHub Actions Permissions
       run: |
         echo "Checking GitHub Actions permissions..."
-        if [ -z "${{ github.token }}" ]; then
+        if ($env:GITHUB_TOKEN -eq $null) {
           echo "GitHub Actions token is not set. Please check repository settings."
           exit 1
-        else
+        } else {
           echo "GitHub Actions token is set."
-        fi
+        }
 
     - name: Clean solution
       run: msbuild AVB_Windows.sln /t:Clean
@@ -378,12 +378,12 @@ jobs:
     - name: Check GitHub Actions Permissions
       run: |
         echo "Checking GitHub Actions permissions..."
-        if [ -z "${{ github.token }}" ]; then
+        if ($env:GITHUB_TOKEN -eq $null) {
           echo "GitHub Actions token is not set. Please check repository settings."
           exit 1
-        else
+        } else {
           echo "GitHub Actions token is set."
-        fi
+        }
 
     - name: Clean solution
       run: msbuild AVB_Windows.sln /t:Clean


### PR DESCRIPTION
Related to #141

Update the `Check GitHub Actions Permissions` step in `.github/workflows/ci.yml` to use the correct PowerShell syntax.

* Replace `if [ -z "${{ github.token }}" ]; then` with `if ($env:GITHUB_TOKEN -eq $null) {`
* Replace `else` with `} else {`
* Replace `fi` with `}`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/AVB-Windows/issues/141?shareId=c955992f-75dd-4d59-9142-49c405cb328b).