### PR TITLE
Fix GitHub Actions permissions check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,12 +72,12 @@ jobs:
     - name: Check GitHub Actions Permissions
       run: |
         echo "Checking GitHub Actions permissions..."
-        if [ -z "${{ github.token }}" ]; then
+        if ($env:GITHUB_TOKEN -eq $null) {
           echo "GitHub Actions token is not set. Please check repository settings."
           exit 1
-        else
+        } else {
           echo "GitHub Actions token is set."
-        fi
+        }
 
     - name: Clean solution
       run: msbuild AVB_Windows.sln /t:Clean
@@ -365,12 +365,12 @@ jobs:
     - name: Check GitHub Actions Permissions
       run: |
         echo "Checking GitHub Actions permissions..."
-        if [ -z "${{ github.token }}" ]; then
+        if ($env:GITHUB_TOKEN -eq $null) {
           echo "GitHub Actions token is not set. Please check repository settings."
           exit 1
-        else
+        } else {
           echo "GitHub Actions token is set."
-        fi
+        }
 
     - name: Clean solution
       run: msbuild AVB_Windows.sln /t:Clean


### PR DESCRIPTION
Related to #141

Update the GitHub Actions workflow to fix the syntax error in the `Check GitHub Actions Permissions` step.

* Replace `if [ -z "${{ github.token }}" ]; then` with `if ($env:GITHUB_TOKEN -eq $null) {` in the `Check GitHub Actions Permissions` step in `.github/workflows/ci.yml`.
* Ensure the correct syntax for checking the GitHub Actions token is set.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/AVB-Windows/issues/141?shareId=532106d2-50b5-48a7-866d-8b6a657b1b1a).