### PR TITLE
Fix GitHub Actions token issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,8 @@ jobs:
         } else {
           echo "GitHub Actions token is set."
         }
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Clean solution
       run: msbuild AVB_Windows.sln /t:Clean
@@ -371,6 +373,8 @@ jobs:
         } else {
           echo "GitHub Actions token is set."
         }
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Clean solution
       run: msbuild AVB_Windows.sln /t:Clean
@@ -454,6 +458,8 @@ jobs:
       run: pip install PyGithub
 
     - name: Check for Log File Existence
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         if [ ! -f build.log ]; then
           echo "No build.log found."

--- a/scripts/error_detection.py
+++ b/scripts/error_detection.py
@@ -11,6 +11,9 @@ def check_for_logs(log_paths):
             existing_logs.append(log_path)
         else:
             print(f"No logs found for {log_path}. Skipping error-checking step.")
+    if not os.environ.get('GITHUB_TOKEN'):
+        print("GITHUB_TOKEN environment variable is not set. Please check repository settings.")
+        return []
     return existing_logs
 
 def parse_logs(log_paths):
@@ -31,6 +34,9 @@ def parse_logs(log_paths):
                     }
                     errors.append(error_info)
                     metadata["error_count"] += 1
+    if not os.environ.get('GITHUB_TOKEN'):
+        print("GITHUB_TOKEN environment variable is not set. Please check repository settings.")
+        return [], metadata
     return errors, metadata
 
 def get_error_context(log_file, error_line_number, context_lines=2):
@@ -47,7 +53,8 @@ def save_errors_and_metadata(errors, metadata, output_path, log_link):
     data = {
         "errors": errors,
         "metadata": metadata,
-        "build_logs_link": log_link
+        "build_logs_link": log_link,
+        "github_token_status": "set" if os.environ.get('GITHUB_TOKEN') else "not set"
     }
     with open(output_path, 'w') as output_file:
         json.dump(data, output_file, indent=4)


### PR DESCRIPTION
Related to #151

Add `GITHUB_TOKEN` environment variable check and set it in GitHub Actions workflow.

* **scripts/error_detection.py**
  - Add `GITHUB_TOKEN` environment variable check in `check_for_logs` function.
  - Update `parse_logs` function to handle missing `GITHUB_TOKEN`.
  - Modify `save_errors_and_metadata` function to include `GITHUB_TOKEN` status.

* **.github/workflows/ci.yml**
  - Add `env` section with `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` in `Check GitHub Actions Permissions` step.
  - Update `Run Issue Creation` step to include `GITHUB_TOKEN`.
  - Modify `Check for Log File Existence` step to include `GITHUB_TOKEN`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/AVB-Windows/issues/151?shareId=90429376-58d0-409c-93c1-b58d216a6fb1).