### PR TITLE
Fix WDK installation verification for Windows 11

### DIFF
--- a/scripts/verify_wdk_installation.sh
+++ b/scripts/verify_wdk_installation.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Set the WDK_IncludePath environment variable
-export WDK_IncludePath="C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0;C:\Program Files (x86)\Windows Kits\11\Include\11.0.22000.0"
+export WDK_IncludePath="C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0;C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\km;C:\Program Files (x86)\Windows Kits\11\Include\11.0.22000.0;C:\Program Files (x86)\Windows Kits\11\Include\11.0.22000.0\km"
 
 # Check if the WDK files are present in the correct installation path for Windows 10
 if [ -d "C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0" ]; then


### PR DESCRIPTION
Related to #159

Update `scripts/verify_wdk_installation.sh` to include additional paths in `WDK_IncludePath`.

* Add the path `C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\km` to the `WDK_IncludePath` environment variable.
* Add the path `C:\Program Files (x86)\Windows Kits\11\Include\11.0.22000.0\km` to the `WDK_IncludePath` environment variable.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/AVB-Windows/issues/159?shareId=48f49373-2ec8-429f-995a-b2eba8f854a7).