### PR TITLE
Fix duplicate identifiers in GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
         if-no-files-found: error
 
     - name: Upload WDK Chocolatey Logs
-      id: upload_chocolatey_logs
+      id: upload_chocolatey_wdk_logs
       uses: actions/upload-artifact@v4
       with:
         name: chocolatey-wdk10-logs-${{ github.job }}-${{ github.run_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
 
     - name: Upload KMDF Chocolatey Logs
       if: failure()
-      id: upload_chocolatey_logs
+      id: upload_chocolatey_kmdf_logs
       uses: actions/upload-artifact@v4
       with:
         name: chocolatey-KMDF-logs-${{ github.job }}-${{ github.run_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
       run: choco install windows-sdk-10 --source=https://chocolatey.org/api/v2/ > install_windows_sdk_10.log 2>&1
 
     - name: Upload Install Windows SDK10 Logs
-      id: upload_install_windows_sdk_logs
+      id: upload_install_windows_sdk10_logs
       uses: actions/upload-artifact@v4
       with:
         name: install-windows-sdk10-logs-${{ github.job }}-${{ github.run_id }}
@@ -94,7 +94,7 @@ jobs:
         if-no-files-found: error
 
     - name: Upload SDK10 Chocolatey Logs
-      id: upload_chocolatey_logs
+      id: upload_chocolatey_sdk10_logs
       uses: actions/upload-artifact@v4
       with:
         name: chocolatey-sdk10-logs-${{ github.job }}-${{ github.run_id }}

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ jobs:
         elif [ "$environment" == "staging" ]; then
           echo "Labeling as 'in staging'"
           # Add logic to label issues as 'in staging'
-        elif [ "$environment" == "production" ]; then
+        elif [ "$environment" == "production"; then
           echo "Labeling as 'in production'"
 
     - name: Enforce Branch Protection Rules


### PR DESCRIPTION
Related to #165

Fix identifier duplication in `.github/workflows/ci.yml`.

* Rename the identifier 'upload_install_windows_sdk_logs' to 'upload_install_windows_sdk10_logs' at line 88.
* Rename the identifier 'upload_chocolatey_logs' to 'upload_chocolatey_sdk10_logs' at line 97.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/AVB-Windows/issues/165?shareId=4065299e-6d17-4f65-8848-cbe57a12856a).